### PR TITLE
Change paradigm from install/uninstall to LTS packages/other packages

### DIFF
--- a/blueprints/ember-frost-lts/index.js
+++ b/blueprints/ember-frost-lts/index.js
@@ -14,12 +14,12 @@ const stateHandler = require('../../lib/models/state')
 const statesEnum = stateHandler.statesEnum
 
 const QUESTION_RECOMMENDED_GROUPS = {
-  name: 'userInputInstallPkgs',
+  name: 'userInputRecommendGroups',
   message: 'Available packages (install)'
 }
 
 const QUESTION_OTHER_GROUPS = {
-  name: 'userInputUninstallPkgs',
+  name: 'userInputOtherGroups',
   message: 'Available packages (uninstall)'
 }
 
@@ -104,10 +104,9 @@ module.exports = {
    * @returns {Promise} a promise to uninstall packages
    */
   unistallPkgs (packages) {
-    const packagesToUninstall = packages[actionsEnum.REMOVE]
-    if (packagesToUninstall) {
-      // TODO packagesToUninstall
-      return this.removePackagesFromProject([])
+    if (packages && packages[actionsEnum.REMOVE]) {
+      const packagesToUninstall = packages[actionsEnum.REMOVE]
+      return this.removePackagesFromProject(packagesToUninstall)
     }
   },
   /**
@@ -116,9 +115,11 @@ module.exports = {
    * @returns {Promise} a promise to install packages
    */
   installPkgs (packages) {
-    const packagesToInstall = packages[actionsEnum.OVERWRITE]
-    if (packagesToInstall && !_.isEmpty(packagesToInstall)) {
-      return this.addAddonsToProject({ packages: packagesToInstall })
+    if (packages) {
+      const packagesToInstall = packages[actionsEnum.OVERWRITE]
+      if (packagesToInstall && !_.isEmpty(packagesToInstall)) {
+        return this.addAddonsToProject({ packages: packagesToInstall })
+      }
     }
   },
 
@@ -460,9 +461,4 @@ module.exports = {
     }
   }
 }
-
-// Tests
-// Uninstall nothing
-// Uninstall 1 pkg + confirm
-// Uninstall 1 pkg + confirm (no) + uninstall 2 pkgs + confirm (yes)
 

--- a/blueprints/ember-frost-lts/index.js
+++ b/blueprints/ember-frost-lts/index.js
@@ -24,6 +24,8 @@ const MESSAGES = {
   CONFIRMATION: 'Would you like to confirm the following choices',
   SUMMARY: 'Summary of the operations that will be done',
   UNINSTALLING_PKGS: 'Uninstalling packages',
+  CHECKING_PACKAGES: 'Checking packages content',
+  CHECKED_PACKAGES: 'Checked packages content',
   INSTALLING_PKGS: 'Installing packages'
 }
 
@@ -58,13 +60,6 @@ module.exports = {
     // not specified (since that doesn't actually matter
     // to us
   },
-  // wait (ms){
-  //   var start = new Date().getTime();
-  //   var end = start;
-  //   while(end < start + ms) {
-  //     end = new Date().getTime();
-  //   }
-  // },
   /**
    * Query the user to determine which packages/groups he wants to install.
    * Note: Some packages/groups are mandatory and the others are optional
@@ -72,6 +67,7 @@ module.exports = {
    * @returns {object} a list of the packages to install
    */
   afterInstall: function (options) {
+    this.displayWelcomeTag()
     display.title(MESSAGES.INSTALLING_LTS)
     display.title(MESSAGES.LOADING_VALIDATING_LTS_FILES)
     const existingPkgs = externalAppPackagesUtil.getExistingPkgs(options)
@@ -101,6 +97,17 @@ module.exports = {
         })
       }
     }
+  },
+  /**
+   * Display welcome tag
+   */
+  displayWelcomeTag () {
+    console.log('.____  ____________________  ')
+    console.log('|    | \\__    ___/   _____/ ')
+    console.log('|    |   |    |  \\_____  \\ ')
+    console.log('|    |___|    |  /        \\ ')
+    console.log('|________\\____| /_________/ ')
+    console.log('Tool to install/uninstall LTS packages\n')
   },
   /**
    * Uninstall and install the packages passed in parameter.
@@ -145,9 +152,15 @@ module.exports = {
       const packagesToInstallByName = this.getPackagesByName(packagesToInstall)
 
       if (packagesToInstall && !_.isEmpty(packagesToInstall)) {
+        let spinner = display.getSpinner(MESSAGES.CHECKING_PACKAGES)
+        spinner.start()
+
         const promises = this.getPkgsInfo(packagesToInstall)
 
         return Promise.all(promises).then((results) => {
+          spinner.stop(true)
+          display.message(MESSAGES.CHECKED_PACKAGES)
+
           let addons = []
           let nonAddons = []
           results.forEach((result) => {

--- a/blueprints/ember-frost-lts/index.js
+++ b/blueprints/ember-frost-lts/index.js
@@ -20,8 +20,8 @@ var MESSAGES = {
   QUESTION_RECOMMENDED_GROUPS:
     'Choose the LTS features to install [' + figures.radioOn + ' ] or uninstall [' + figures.radioOff + ' ]',
   QUESTION_OTHER_GROUPS:
-    'Choose the application specific packages to keep [' +
-    figures.radioOn + ' ] or uninstall [' + figures.radioOff + ' ]',
+    'Choose the application specific packages to keep [' + figures.radioOn +
+    ' ] or uninstall [' + figures.radioOff + ' ]',
   INSTALLING_LTS: 'Installing LTS',
   LOADING_VALIDATING_LTS_FILES: 'Loading and validating LTS files',
   LOADED_VALIDATED_LTS_FILES: 'Loaded and validated LTS files\n',

--- a/blueprints/ember-frost-lts/index.js
+++ b/blueprints/ember-frost-lts/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const _ = require('lodash')
+const figures = require('figures')
 
 const actionHandler = require('../../lib/models/action')
 const actionsEnum = actionHandler.actionsEnum
@@ -16,8 +17,10 @@ const npm = require('../../lib/utils/npm')
 const display = require('../../lib/ui/display')
 
 const MESSAGES = {
-  QUESTION_RECOMMENDED_GROUPS: 'Choose the LTS features to install/uninstall',
-  QUESTION_OTHER_GROUPS: 'Choose the non LTS packages to keep/uninstall',
+  QUESTION_RECOMMENDED_GROUPS:
+    `Choose the LTS features to install [${figures.radioOn} ] or uninstall [${figures.radioOff} ]`,
+  QUESTION_OTHER_GROUPS:
+    `Choose the non LTS packages to keep$ [${figures.radioOn} ] or uninstall [${figures.radioOff} ]`,
   INSTALLING_LTS: 'Installing LTS',
   LOADING_VALIDATING_LTS_FILES: 'Loading and validating LTS files',
   LOADED_VALIDATED_LTS_FILES: 'Loaded and validated LTS files\n',

--- a/blueprints/ember-frost-lts/index.js
+++ b/blueprints/ember-frost-lts/index.js
@@ -18,9 +18,9 @@ const display = require('../../lib/ui/display')
 
 const MESSAGES = {
   QUESTION_RECOMMENDED_GROUPS:
-    `Choose the LTS features to install [${figures.radioOn} ] or uninstall [${figures.radioOff} ]`,
+    'Choose the LTS features to install [' + figures.radioOn + ' ] or uninstall [' + figures.radioOff + ' ]',
   QUESTION_OTHER_GROUPS:
-    `Choose the non LTS packages to keep$ [${figures.radioOn} ] or uninstall [${figures.radioOff} ]`,
+    'Choose the non LTS packages to keep$ [' + figures.radioOn + ' ] or uninstall [' + figures.radioOff + ' ]',
   INSTALLING_LTS: 'Installing LTS',
   LOADING_VALIDATING_LTS_FILES: 'Loading and validating LTS files',
   LOADED_VALIDATED_LTS_FILES: 'Loaded and validated LTS files\n',
@@ -81,22 +81,24 @@ module.exports = {
     const recommendGroupsPromise = this.getSelectedRecommendedPkgs(recommendedGroups)
 
     if (recommendGroupsPromise) {
-      return recommendGroupsPromise.then((recommendedPackagesToModify) => {
-        const otherGroupsPromise = this.getSelectedOtherPkgs(otherGroups)
+      const self = this
+      return recommendGroupsPromise.then(function (recommendedPackagesToModify) {
+        const otherGroupsPromise = self.getSelectedOtherPkgs(otherGroups)
         if (otherGroupsPromise) {
-          return otherGroupsPromise.then((otherPackagesToModify) => {
+          return otherGroupsPromise.then(function (otherPackagesToModify) {
             const pkgsToModify = objUtil.merge(otherPackagesToModify, recommendedPackagesToModify)
-            return this.uninstallAndInstallPkgs(pkgsToModify)
+            return self.uninstallAndInstallPkgs(pkgsToModify)
           })
         } else {
-          return this.uninstallAndInstallPkgs(recommendedPackagesToModify)
+          return self.uninstallAndInstallPkgs(recommendedPackagesToModify)
         }
       })
     } else {
       const otherGroupsPromise = this.getSelectedOtherPkgs(otherGroups)
       if (otherGroupsPromise) {
-        return otherGroupsPromise.then((otherPackagesToModify) => {
-          return this.uninstallAndInstallPkgs(otherPackagesToModify)
+        const self = this
+        return otherGroupsPromise.then(function (otherPackagesToModify) {
+          return self.uninstallAndInstallPkgs(otherPackagesToModify)
         })
       }
     }
@@ -124,8 +126,9 @@ module.exports = {
 
     // Install the packages
     if (removePackagesPromise) {
-      return removePackagesPromise.then(() => {
-        return this.installPkgs(packages)
+      const self = this
+      return removePackagesPromise.then(function () {
+        return self.installPkgs(packages)
       })
     } else {
       return this.installPkgs(packages)
@@ -160,25 +163,26 @@ module.exports = {
 
         const promises = this.getPkgsInfo(packagesToInstall)
 
-        return Promise.all(promises).then((results) => {
+        const self = this
+        return Promise.all(promises).then(function (results) {
           spinner.stop(true)
           display.message(MESSAGES.CHECKED_PACKAGES)
 
           let addons = []
           let nonAddons = []
-          results.forEach((result) => {
+          results.forEach(function (result) {
             const pkg = packagesToInstallByName[result.name]
-            if (this.isAddon(result)) {
+            if (self.isAddon(result)) {
               addons.push(pkg)
             } else {
               nonAddons.push(pkg)
             }
           })
 
-          const addAddonsPromise = this.addAddonsToProject({ packages: addons })
+          const addAddonsPromise = self.addAddonsToProject({ packages: addons })
           let addPkgsPromise
           if (!_.isEmpty(nonAddons)) {
-            addPkgsPromise = this.addPackagesToProject(nonAddons)
+            addPkgsPromise = self.addPackagesToProject(nonAddons)
           }
 
           return Promise.all([addAddonsPromise, addPkgsPromise])
@@ -201,7 +205,7 @@ module.exports = {
    */
   getPkgsInfo (packages) {
     let promises = []
-    packages.forEach((pkg) => {
+    packages.forEach(function (pkg) {
       promises.push(npm.view(packageHandler.toString(pkg.name, pkg)))
     })
     return promises
@@ -214,7 +218,7 @@ module.exports = {
   getPackagesByName (packages) {
     const packagesByName = {}
     if (!_.isEmpty(packages)) {
-      packages.forEach((pkg) => {
+      packages.forEach(function (pkg) {
         packagesByName[pkg.name] = pkg
       })
     }
@@ -413,20 +417,21 @@ module.exports = {
     const choices = this.getChoices(groups, question, getChoicesFct, previousUserInputs)
     const promise = this.getUserInputForGroups(groups, question, choices)
     if (promise) {
-      return promise.then((userInputs) => {
+      const self = this
+      return promise.then(function (userInputs) {
         // Once we get the input of the user, we display a summary and we ask
         // the user to confirm the action for each group.
         const actionByGroup = actionHandler.getByEntity(groups,
                                         userInputs[question.name],
                                         getActionByGroupFct)
         // Display summary
-        this.displaySummary(groups, actionByGroup)
+        self.displaySummary(groups, actionByGroup)
         // Confirm choices
-        return this.getConfirmedPkgsSelected(
+        return self.getConfirmedPkgsSelected(
           actionByGroup,
-          { fct: this.getPackagesToModify.bind(this),
+          { fct: self.getPackagesToModify.bind(self),
             params: {groups, actionByGroup}},
-          { fct: this.getSelectedPkgs.bind(this),
+          { fct: self.getSelectedPkgs.bind(self),
             params: {groups, question, getChoicesFct, getActionByGroupFct, userInputs}})
       })
     }
@@ -481,7 +486,7 @@ module.exports = {
    */
   getConfirmedPkgsSelected (actionByGroup, getSelected, goBackToSelection) {
     if (this.isConfirmationRequired(actionByGroup)) {
-      return this.getConfirmationUserInput(QUESTION_CONFIRM).then((confirmUserInput) => {
+      return this.getConfirmationUserInput(QUESTION_CONFIRM).then(function (confirmUserInput) {
         if (confirmUserInput[QUESTION_CONFIRM.name]) {
           display.carriageReturn()
           const params = getSelected.params
@@ -554,7 +559,7 @@ module.exports = {
    */
   getSummaryByGroup (name, group, action) {
     if (name && group && action) {
-      return `${actionHandler.toString(action)} ${groupHandler.toString(name, group)}`
+      return actionHandler.toString(action) + ' ' + groupHandler.toString(name, group)
     }
   }
 }

--- a/blueprints/ember-frost-lts/index.js
+++ b/blueprints/ember-frost-lts/index.js
@@ -1,22 +1,22 @@
 'use strict'
 
-const _ = require('lodash')
-const figures = require('figures')
+var _ = require('lodash')
+var figures = require('figures')
 
-const actionHandler = require('../../lib/models/action')
-const actionsEnum = actionHandler.actionsEnum
-const userInputHandler = require('../../lib/ui/user-input')
-const groupHandler = require('../../lib/models/group')
-const packageHandler = require('../../lib/models/package')
-const externalAppPackagesUtil = require('../../lib/utils/external-app-packages')
-const requestedPackagesUtil = require('../../lib/utils/requested-packages')
-const objUtil = require('../../lib/utils/obj')
-const stateHandler = require('../../lib/models/state')
-const statesEnum = stateHandler.statesEnum
-const npm = require('../../lib/utils/npm')
-const display = require('../../lib/ui/display')
+var actionHandler = require('../../lib/models/action')
+var actionsEnum = actionHandler.actionsEnum
+var userInputHandler = require('../../lib/ui/user-input')
+var groupHandler = require('../../lib/models/group')
+var packageHandler = require('../../lib/models/package')
+var externalAppPackagesUtil = require('../../lib/utils/external-app-packages')
+var requestedPackagesUtil = require('../../lib/utils/requested-packages')
+var objUtil = require('../../lib/utils/obj')
+var stateHandler = require('../../lib/models/state')
+var statesEnum = stateHandler.statesEnum
+var npm = require('../../lib/utils/npm')
+var display = require('../../lib/ui/display')
 
-const MESSAGES = {
+var MESSAGES = {
   QUESTION_RECOMMENDED_GROUPS:
     'Choose the LTS features to install [' + figures.radioOn + ' ] or uninstall [' + figures.radioOff + ' ]',
   QUESTION_OTHER_GROUPS:
@@ -32,22 +32,22 @@ const MESSAGES = {
   INSTALLING_PKGS: 'Installing packages'
 }
 
-const QUESTION_RECOMMENDED_GROUPS = {
+var QUESTION_RECOMMENDED_GROUPS = {
   name: 'userInputRecommendGroups',
   message: MESSAGES.QUESTION_RECOMMENDED_GROUPS
 }
 
-const QUESTION_OTHER_GROUPS = {
+var QUESTION_OTHER_GROUPS = {
   name: 'userInputOtherGroups',
   message: MESSAGES.QUESTION_OTHER_GROUPS
 }
 
-const QUESTION_CONFIRM = {
+var QUESTION_CONFIRM = {
   name: 'confirmSelection',
   message: MESSAGES.CONFIRMATION
 }
 
-const MANDATORY_TO_STR = 'mandatory'
+var MANDATORY_TO_STR = 'mandatory'
 
 module.exports = {
   description: 'Install requested packages',
@@ -73,20 +73,20 @@ module.exports = {
     this.displayWelcomeTag()
     display.title(MESSAGES.INSTALLING_LTS)
     display.title(MESSAGES.LOADING_VALIDATING_LTS_FILES)
-    const existingPkgs = externalAppPackagesUtil.getExistingPkgs(options)
-    const recommendedGroups = this.getRecommendedGroups(options, existingPkgs)
-    const otherGroups = this.getOtherGroups(existingPkgs, recommendedGroups)
+    var existingPkgs = externalAppPackagesUtil.getExistingPkgs(options)
+    var recommendedGroups = this.getRecommendedGroups(options, existingPkgs)
+    var otherGroups = this.getOtherGroups(existingPkgs, recommendedGroups)
     display.title(MESSAGES.LOADED_VALIDATED_LTS_FILES)
 
-    const recommendGroupsPromise = this.getSelectedRecommendedPkgs(recommendedGroups)
+    var recommendGroupsPromise = this.getSelectedRecommendedPkgs(recommendedGroups)
 
+    var self = this
     if (recommendGroupsPromise) {
-      const self = this
       return recommendGroupsPromise.then(function (recommendedPackagesToModify) {
-        const otherGroupsPromise = self.getSelectedOtherPkgs(otherGroups)
+        var otherGroupsPromise = self.getSelectedOtherPkgs(otherGroups)
         if (otherGroupsPromise) {
           return otherGroupsPromise.then(function (otherPackagesToModify) {
-            const pkgsToModify = objUtil.merge(otherPackagesToModify, recommendedPackagesToModify)
+            var pkgsToModify = _.mergeWith(otherPackagesToModify, recommendedPackagesToModify, objUtil.mergeArray)
             return self.uninstallAndInstallPkgs(pkgsToModify)
           })
         } else {
@@ -94,9 +94,8 @@ module.exports = {
         }
       })
     } else {
-      const otherGroupsPromise = this.getSelectedOtherPkgs(otherGroups)
+      var otherGroupsPromise = this.getSelectedOtherPkgs(otherGroups)
       if (otherGroupsPromise) {
-        const self = this
         return otherGroupsPromise.then(function (otherPackagesToModify) {
           return self.uninstallAndInstallPkgs(otherPackagesToModify)
         })
@@ -106,7 +105,7 @@ module.exports = {
   /**
    * Display welcome tag
    */
-  displayWelcomeTag () {
+  displayWelcomeTag: function () {
     console.log('.____  ____________________  ')
     console.log('|    | \\__    ___/   _____/ ')
     console.log('|    |   |    |  \\_____  \\ ')
@@ -119,14 +118,14 @@ module.exports = {
    * @param {object} packages the packages to install/uninstall
    * @returns {Promise} a promise to uninstall/install packages
    */
-  uninstallAndInstallPkgs (packages) {
+  uninstallAndInstallPkgs: function (packages) {
     display.carriageReturn()
     // Unistall the packages
-    let removePackagesPromise = this.unistallPkgs(packages)
+    var removePackagesPromise = this.unistallPkgs(packages)
 
     // Install the packages
     if (removePackagesPromise) {
-      const self = this
+      var self = this
       return removePackagesPromise.then(function () {
         return self.installPkgs(packages)
       })
@@ -139,10 +138,10 @@ module.exports = {
    * @param {object} packages the packages to install/uninstall
    * @returns {Promise} a promise to uninstall packages
    */
-  unistallPkgs (packages) {
+  unistallPkgs: function (packages) {
     if (packages && packages[actionsEnum.REMOVE]) {
       display.title(MESSAGES.UNINSTALLING_PKGS)
-      const packagesToUninstall = packages[actionsEnum.REMOVE]
+      var packagesToUninstall = packages[actionsEnum.REMOVE]
       return this.removePackagesFromProject(packagesToUninstall)
     }
   },
@@ -151,27 +150,27 @@ module.exports = {
    * @param {object} packages the packages to install/uninstall
    * @returns {Promise} a promise to install packages
    */
-  installPkgs (packages) {
+  installPkgs: function (packages) {
     if (packages) {
       display.title(MESSAGES.INSTALLING_PKGS)
-      const packagesToInstall = packages[actionsEnum.OVERWRITE]
-      const packagesToInstallByName = this.getPackagesByName(packagesToInstall)
+      var packagesToInstall = packages[actionsEnum.OVERWRITE]
+      var packagesToInstallByName = this.getPackagesByName(packagesToInstall)
 
       if (packagesToInstall && !_.isEmpty(packagesToInstall)) {
-        let spinner = display.getSpinner(MESSAGES.CHECKING_PACKAGES)
+        var spinner = display.getSpinner(MESSAGES.CHECKING_PACKAGES)
         spinner.start()
 
-        const promises = this.getPkgsInfo(packagesToInstall)
+        var promises = this.getPkgsInfo(packagesToInstall)
 
-        const self = this
+        var self = this
         return Promise.all(promises).then(function (results) {
           spinner.stop(true)
           display.message(MESSAGES.CHECKED_PACKAGES)
 
-          let addons = []
-          let nonAddons = []
+          var addons = []
+          var nonAddons = []
           results.forEach(function (result) {
-            const pkg = packagesToInstallByName[result.name]
+            var pkg = packagesToInstallByName[result.name]
             if (self.isAddon(result)) {
               addons.push(pkg)
             } else {
@@ -179,8 +178,8 @@ module.exports = {
             }
           })
 
-          const addAddonsPromise = self.addAddonsToProject({ packages: addons })
-          let addPkgsPromise
+          var addAddonsPromise = self.addAddonsToProject({ packages: addons })
+          var addPkgsPromise
           if (!_.isEmpty(nonAddons)) {
             addPkgsPromise = self.addPackagesToProject(nonAddons)
           }
@@ -195,7 +194,7 @@ module.exports = {
    * @param {object} pkgInfo the information of the package
    * @returns {boolean} true if the package is an addon and false otherwise
    */
-  isAddon (pkgInfo) {
+  isAddon: function (pkgInfo) {
     return pkgInfo.keywords.indexOf('ember-addon') > -1
   },
   /**
@@ -203,8 +202,8 @@ module.exports = {
    * @param {array} packages a list of package
    * @returns {array} a list of promises to get the information of all the packages
    */
-  getPkgsInfo (packages) {
-    let promises = []
+  getPkgsInfo: function (packages) {
+    var promises = []
     packages.forEach(function (pkg) {
       promises.push(npm.view(packageHandler.toString(pkg.name, pkg)))
     })
@@ -215,8 +214,8 @@ module.exports = {
    * @param {array} packages a list of packages
    * @returns {object} the packages in an object
    */
-  getPackagesByName (packages) {
-    const packagesByName = {}
+  getPackagesByName: function (packages) {
+    var packagesByName = {}
     if (!_.isEmpty(packages)) {
       packages.forEach(function (pkg) {
         packagesByName[pkg.name] = pkg
@@ -233,29 +232,28 @@ module.exports = {
    * @param {object} existingPkgs the existing packages
    * @returns {object} contains all the groups.
    */
-  getRecommendedGroups (options, existingPkgs) {
-    const isThisAddonInstalled = externalAppPackagesUtil.isThisAddonInstalled(options)
+  getRecommendedGroups: function (options, existingPkgs) {
+    var isThisAddonInstalled = externalAppPackagesUtil.isThisAddonInstalled(options)
 
     // Get the mandatory groups
-    const mandatoryRequestedGroupsNPkgs = requestedPackagesUtil.getMandatoryGroupsNPkgs(options)
-    const mandatoryGroups = groupHandler.createRequestedGroups(mandatoryRequestedGroupsNPkgs, existingPkgs,
+    var mandatoryRequestedGroupsNPkgs = requestedPackagesUtil.getMandatoryGroupsNPkgs(options)
+    var mandatoryGroups = groupHandler.createRequestedGroups(mandatoryRequestedGroupsNPkgs, existingPkgs,
                         isThisAddonInstalled, true)
 
     // Get the optional groups
-    const optionalRequestedGroupsNPkgs = requestedPackagesUtil.getOptionalGroupsNPkgs(options)
-    const optionalGroups = groupHandler.createRequestedGroups(optionalRequestedGroupsNPkgs, existingPkgs,
+    var optionalRequestedGroupsNPkgs = requestedPackagesUtil.getOptionalGroupsNPkgs(options)
+    var optionalGroups = groupHandler.createRequestedGroups(optionalRequestedGroupsNPkgs, existingPkgs,
                         isThisAddonInstalled, false)
 
     // Get all the groups
-    return objUtil.merge(mandatoryGroups, optionalGroups)
+    return _.merge(mandatoryGroups, optionalGroups, objUtil.mergeArray)
   },
   /**
    * Get the recommended packages.
    * @param {object} groups all recommended the groups
    * @returns {Promise} a promise that will return all the selected recommended packages
    */
-  // TODO: note in pkg.json dependency node 5 + bcs of bind
-  getSelectedRecommendedPkgs (groups) {
+  getSelectedRecommendedPkgs: function (groups) {
     return this.getSelectedPkgs(
       groups,
       QUESTION_RECOMMENDED_GROUPS,
@@ -269,8 +267,8 @@ module.exports = {
    * @param {boolean} isInUserInput true if the user selected that group and false otherwise
    * @returns {string} the action for this group
    */
-  getActionForRecommendedGroup (name, group, isInUserInput) {
-    let action = actionsEnum.SKIP
+  getActionForRecommendedGroup: function (name, group, isInUserInput) {
+    var action = actionsEnum.SKIP
 
     if (isInUserInput || group.isMandatory) {
       action = actionsEnum.OVERWRITE
@@ -291,8 +289,8 @@ module.exports = {
    * @param {object} groupsToExclude all the groups that need to be excluded
    * @returns {object} contains all the other groups
    */
-  getOtherGroups (existingPkgs, groupsToExclude) {
-    const otherPackages = this.getOtherPkgs(existingPkgs, groupsToExclude)
+  getOtherGroups: function (existingPkgs, groupsToExclude) {
+    var otherPackages = this.getOtherPkgs(existingPkgs, groupsToExclude)
     return groupHandler.createGroups(otherPackages)
   },
   /**
@@ -301,12 +299,12 @@ module.exports = {
    * @param {object} groupsToExclude the groups to exclude
    * @returns {object} contains all the other packages
    */
-  getOtherPkgs (existingPkgs, groupsToExclude) {
-    let otherPackages = {}
-    const packagesToExclude = groupHandler.getPackageNames(groupsToExclude)
+  getOtherPkgs: function (existingPkgs, groupsToExclude) {
+    var otherPackages = {}
+    var packagesToExclude = groupHandler.getPackageNames(groupsToExclude)
 
-    for (let pkgName in existingPkgs) {
-      const pkg = existingPkgs[pkgName]
+    for (var pkgName in existingPkgs) {
+      var pkg = existingPkgs[pkgName]
       if (packagesToExclude.indexOf(pkgName) === -1) {
         otherPackages[pkgName] = pkg
       }
@@ -318,7 +316,7 @@ module.exports = {
    * @param {object} groups all the other groups
    * @returns {Promise} a promise that will return all the other selected packages
    */
-  getSelectedOtherPkgs (groups) {
+  getSelectedOtherPkgs: function (groups) {
     return this.getSelectedPkgs(
       groups,
       QUESTION_OTHER_GROUPS,
@@ -332,8 +330,8 @@ module.exports = {
    * @param {boolean} isInUserInput true if the user selected that group and false otherwise
    * @returns {string} the action for this group
    */
-  getActionForOtherGroup (name, group, isInUserInput) {
-    let action = actionsEnum.SKIP
+  getActionForOtherGroup: function (name, group, isInUserInput) {
+    var action = actionsEnum.SKIP
 
     if (group.state === statesEnum.INSTALLED) {
       if (isInUserInput) {
@@ -354,7 +352,7 @@ module.exports = {
    * @param {boolean} wasInUserInput true is the user previously selected that choice
    * @returns {object} the choice for a group
    */
-  getChoiceForGroup (name, group, wasInUserInput) {
+  getChoiceForGroup: function (name, group, wasInUserInput) {
     return {
       value: name,
       name: groupHandler.toString(name, group),
@@ -367,7 +365,7 @@ module.exports = {
    * @param {object} group the group
    * @returns {boolean} true if the group is selected by default and false otherwise
    */
-  isGroupSelectedByDefault (group) {
+  isGroupSelectedByDefault: function (group) {
     return group.state === statesEnum.INSTALLED || group.isMandatory || this.isCandidateForAutomaticUpdate(group)
   },
   /**
@@ -375,7 +373,7 @@ module.exports = {
    * @param {object} group the group
    * @returns {boolean} true if the group is a candidate for an automatic update and false otherwise
    */
-  isCandidateForAutomaticUpdate (group) {
+  isCandidateForAutomaticUpdate: function (group) {
     return group.state === statesEnum.NEED_UPDATE && group.isThisAddonInstalled
   },
   /**
@@ -383,7 +381,7 @@ module.exports = {
    * @param {object} group the group
    * @returns {boolean} true if the group is disabled by default and false otherwise
    */
-  isGroupDisabledByDefault (group) {
+  isGroupDisabledByDefault: function (group) {
     if (group.isMandatory) {
       return MANDATORY_TO_STR
     }
@@ -400,8 +398,8 @@ module.exports = {
    * @param {object} previousUserInputs the previous user inputs (will be null on the first call of this method)
    * @returns {object} all the choices
    */
-  getChoices (groups, question, getChoicesFct, previousUserInputs) {
-    const choicesSelectedPreviously = (previousUserInputs === undefined) ? undefined : previousUserInputs[question.name]
+  getChoices: function (groups, question, getChoicesFct, previousUserInputs) {
+    var choicesSelectedPreviously = (previousUserInputs === undefined) ? undefined : previousUserInputs[question.name]
     return userInputHandler.getChoices(groups, getChoicesFct, choicesSelectedPreviously)
   },
   /**
@@ -413,15 +411,15 @@ module.exports = {
    * @param {object} previousUserInputs the previous user inputs (will be null on the first call of this method)
    * @returns {Promise} a promise that will return all the selected groups
    */
-  getSelectedPkgs (groups, question, getChoicesFct, getActionByGroupFct, previousUserInputs) {
-    const choices = this.getChoices(groups, question, getChoicesFct, previousUserInputs)
-    const promise = this.getUserInputForGroups(groups, question, choices)
+  getSelectedPkgs: function (groups, question, getChoicesFct, getActionByGroupFct, previousUserInputs) {
+    var choices = this.getChoices(groups, question, getChoicesFct, previousUserInputs)
+    var promise = this.getUserInputForGroups(groups, question, choices)
     if (promise) {
-      const self = this
+      var self = this
       return promise.then(function (userInputs) {
         // Once we get the input of the user, we display a summary and we ask
         // the user to confirm the action for each group.
-        const actionByGroup = actionHandler.getByEntity(groups,
+        var actionByGroup = actionHandler.getByEntity(groups,
                                         userInputs[question.name],
                                         getActionByGroupFct)
         // Display summary
@@ -430,9 +428,20 @@ module.exports = {
         return self.getConfirmedPkgsSelected(
           actionByGroup,
           { fct: self.getPackagesToModify.bind(self),
-            params: {groups, actionByGroup}},
+            params: {
+              groups: groups,
+              actionByGroup: actionByGroup
+            }
+          },
           { fct: self.getSelectedPkgs.bind(self),
-            params: {groups, question, getChoicesFct, getActionByGroupFct, userInputs}})
+            params: {
+              groups: groups,
+              question: question,
+              getChoicesFct: getChoicesFct,
+              getActionByGroupFct: getActionByGroupFct,
+              userInputs: userInputs
+            }
+          })
       })
     }
   },
@@ -442,15 +451,15 @@ module.exports = {
    * @param {object} actionByGroup the action that will be done for each group
    * @returns {object} a list of packages by action
    */
-  getPackagesToModify (groups, actionByGroup) {
-    let packagesByAction = {}
-    for (let groupName in groups) {
-      const group = groups[groupName]
-      const action = actionByGroup[groupName]
+  getPackagesToModify: function (groups, actionByGroup) {
+    var packagesByAction = {}
+    for (var groupName in groups) {
+      var group = groups[groupName]
+      var action = actionByGroup[groupName]
 
-      const pkgsToModifyByAction = this.getPackagesToModifyByActionForGroup(group, action)
+      var pkgsToModifyByAction = this.getPackagesToModifyByActionForGroup(group, action)
       if (!_.isEmpty(pkgsToModifyByAction)) {
-        let currentPackagesByAction = packagesByAction[action]
+        var currentPackagesByAction = packagesByAction[action]
 
         if (!currentPackagesByAction) {
           currentPackagesByAction = []
@@ -468,8 +477,8 @@ module.exports = {
    * @param {string} action the action to do on the group
    * @returns {object} a list of packages by action
    */
-  getPackagesToModifyByActionForGroup (group, action) {
-    let packagesToModifyByAction = {}
+  getPackagesToModifyByActionForGroup: function (group, action) {
+    var packagesToModifyByAction = {}
     if (action === actionsEnum.OVERWRITE || action === actionsEnum.REMOVE) {
       packagesToModifyByAction[action] = groupHandler.getPkgsBy(group, packageHandler.getPackageObj)
     }
@@ -484,15 +493,16 @@ module.exports = {
    * @returns {Promise} a promise that will return back the user to the selection or
    *          {object} a list of the packages selected
    */
-  getConfirmedPkgsSelected (actionByGroup, getSelected, goBackToSelection) {
+  getConfirmedPkgsSelected: function (actionByGroup, getSelected, goBackToSelection) {
     if (this.isConfirmationRequired(actionByGroup)) {
       return this.getConfirmationUserInput(QUESTION_CONFIRM).then(function (confirmUserInput) {
+        var params
         if (confirmUserInput[QUESTION_CONFIRM.name]) {
           display.carriageReturn()
-          const params = getSelected.params
+          params = getSelected.params
           return getSelected.fct(params.groups, params.actionByGroup)
         } else {
-          const params = goBackToSelection.params
+          params = goBackToSelection.params
           return goBackToSelection.fct(params.groups, params.question, params.getChoicesFct,
             params.getActionByGroupFct, params.userInputs)
         }
@@ -504,7 +514,7 @@ module.exports = {
    * @param {object} question the question to ask the user
    * @returns {Promise} the promise containing the user input
    */
-  getConfirmationUserInput (question) {
+  getConfirmationUserInput: function (question) {
     return userInputHandler.getUserInputForChoice(this,
       {type: 'confirm', name: question.name, message: question.message}, [])
   },
@@ -513,7 +523,7 @@ module.exports = {
    * @param {object} actionByGroup the action that will be done for each group
    * @returns {boolean} true if the confirmation is required for the actions to be done by groups and false otherwise
    */
-  isConfirmationRequired (actionByGroup) {
+  isConfirmationRequired: function (actionByGroup) {
     return actionHandler.isAnyActionCompliant(actionByGroup, this.isConfirmationRequiredForGroup)
   },
   /**
@@ -521,7 +531,7 @@ module.exports = {
    * @param {string} action the action to do on the group
    * @returns {boolean} true if a confirmation is required for this group and false otherwise
    */
-  isConfirmationRequiredForGroup (action) {
+  isConfirmationRequiredForGroup: function (action) {
     return action !== actionsEnum.IDENTICAL
   },
   /**
@@ -531,7 +541,7 @@ module.exports = {
    * @param {array} choices the choices that will be shown to the user
    * @returns {Promise} the promise containing the user input
    */
-  getUserInputForGroups (groups, question, choices) {
+  getUserInputForGroups: function (groups, question, choices) {
     if (!_.isEmpty(choices)) {
       return userInputHandler.getUserInputForChoice(this,
         {type: 'checkbox', name: question.name, message: question.message}, choices)
@@ -544,9 +554,9 @@ module.exports = {
    * @param {object} groups all the groups
    * @param {object} actionByGroup the action that will be done for each group
    */
-  displaySummary (groups, actionByGroup) {
+  displaySummary: function (groups, actionByGroup) {
     display.title(MESSAGES.SUMMARY)
-    for (let groupName in groups) {
+    for (var groupName in groups) {
       display.message(this.getSummaryByGroup(groupName, groups[groupName], actionByGroup[groupName]))
     }
   },
@@ -557,7 +567,7 @@ module.exports = {
    * @param {string} action the action to do on the group
    * @returns {string} a summary for a group
    */
-  getSummaryByGroup (name, group, action) {
+  getSummaryByGroup: function (name, group, action) {
     if (name && group && action) {
       return actionHandler.toString(action) + ' ' + groupHandler.toString(name, group)
     }

--- a/lib/models/action.js
+++ b/lib/models/action.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const chalk = require('chalk')
+var chalk = require('chalk')
 
 module.exports = {
   /**
@@ -18,8 +18,8 @@ module.exports = {
    * @param {string} action an action
    * @returns {string} action in string
    */
-  toString (action) {
-    const chalkColor = this._getChalkColor(action)
+  toString: function (action) {
+    var chalkColor = this._getChalkColor(action)
     return chalkColor(action)
   },
   /**
@@ -27,7 +27,7 @@ module.exports = {
    * @param {string} action an action
    * @returns {function} the chalk color function for an action
    */
-  _getChalkColor (action) {
+  _getChalkColor: function (action) {
     if (action === this.actionsEnum.IDENTICAL || action === this.actionsEnum.SKIP) {
       return chalk.yellow
     } else if (action === this.actionsEnum.OVERWRITE || action === this.actionsEnum.REMOVE) {
@@ -41,13 +41,13 @@ module.exports = {
    * @param {function} getActionForEntityFct function that return the action that map with this entity
    * @returns {object} the action for each entity
    */
-  getByEntity (entities, userInputs, getActionForEntityFct) {
-    let actionByEntity = {}
+  getByEntity: function (entities, userInputs, getActionForEntityFct) {
+    var actionByEntity = {}
     if (entities) {
-      for (let id in entities) {
-        const entity = entities[id]
+      for (var id in entities) {
+        var entity = entities[id]
 
-        const isInUserInput = userInputs && userInputs.indexOf(id) > -1
+        var isInUserInput = userInputs && userInputs.indexOf(id) > -1
         actionByEntity[id] = getActionForEntityFct(id, entity, isInUserInput)
       }
     }
@@ -60,10 +60,10 @@ module.exports = {
    * @param {function} isActionCompliantFct function to determine if the action is compliant
    * @returns {boolean} true if any action is compliant with the condition and false otherwise
    */
-  isAnyActionCompliant (actionByEntity, isActionCompliantFct) {
+  isAnyActionCompliant: function (actionByEntity, isActionCompliantFct) {
     if (actionByEntity) {
-      for (let id in actionByEntity) {
-        const action = actionByEntity[id]
+      for (var id in actionByEntity) {
+        var action = actionByEntity[id]
         if (isActionCompliantFct(action)) {
           return true
         }

--- a/lib/models/action.js
+++ b/lib/models/action.js
@@ -10,9 +10,9 @@ module.exports = {
     OVERWRITE: 'overwrite',
     SKIP: 'skip',
     IDENTICAL: 'identical',
-    DIFF: 'diff',
     REMOVE: 'remove'
   },
+
   /**
    * Get an action in string.
    * @param {string} action an action
@@ -22,6 +22,7 @@ module.exports = {
     var chalkColor = this._getChalkColor(action)
     return chalkColor(action)
   },
+
   /**
    * Get the chalk color for an action.
    * @param {string} action an action
@@ -34,6 +35,7 @@ module.exports = {
       return chalk.red
     }
   },
+
   /**
    * Get the action by for each entity.
    * @param {object} entities contains all the entities
@@ -54,6 +56,7 @@ module.exports = {
 
     return actionByEntity
   },
+
   /**
    * Return true if any action is compliant with the condition and false otherwise.
    * @param {object} actionByEntity the action for each entity

--- a/lib/models/action.js
+++ b/lib/models/action.js
@@ -38,17 +38,17 @@ module.exports = {
    * Get the action by for each entity.
    * @param {object} entities contains all the entities
    * @param {array} userInputs contains the id of the entity if the user selected that entity
-   * @param {function} getActionForEntity function that return the action that map with this entity
+   * @param {function} getActionForEntityFct function that return the action that map with this entity
    * @returns {object} the action for each entity
    */
-  getByEntity (entities, userInputs, getActionForEntity) {
+  getByEntity (entities, userInputs, getActionForEntityFct) {
     let actionByEntity = {}
     if (entities) {
       for (let id in entities) {
         const entity = entities[id]
 
         const isInUserInput = userInputs && userInputs.indexOf(id) > -1
-        actionByEntity[id] = getActionForEntity(id, entity, isInUserInput)
+        actionByEntity[id] = getActionForEntityFct(id, entity, isInUserInput)
       }
     }
 

--- a/lib/models/group.js
+++ b/lib/models/group.js
@@ -22,14 +22,14 @@ module.exports = {
       if (group.isGroup) {
         const packages = this.getPkgsBy(group, packageHandler.toString)
         if (packages) {
-          const pkgToStr = (packages && !_.isEmpty(packages)) ? `(${packages.join(', ')})` : ''
-          toString = `${name} ${pkgToStr}`
+          const pkgToStr = (packages && !_.isEmpty(packages)) ? '(' + packages.join(', ') + ')' : ''
+          toString = name + ' ' + pkgToStr
         }
       } else {
         const pkg = this._getPkgs(group)[name]
         const pkgToStr = packageHandler.toString(name, pkg)
         if (pkgToStr) {
-          toString = `${pkgToStr}`
+          toString = pkgToStr
         }
       }
 
@@ -75,7 +75,7 @@ module.exports = {
 
       const pkgs = this.getPkgsBy(group, packageHandler.getPackageObj)
 
-      packageNames = packageNames.concat(pkgs.map((pkg) => { return pkg.name }))
+      packageNames = packageNames.concat(pkgs.map(function (pkg) { return pkg.name }))
     }
 
     return packageNames

--- a/lib/models/group.js
+++ b/lib/models/group.js
@@ -5,6 +5,7 @@ const _ = require('lodash')
 const packageHandler = require('./package')
 const stateHandler = require('./state')
 const statesEnum = stateHandler.statesEnum
+const display = require('../ui/display')
 
 const STATES_BY_PRIORITY = [statesEnum.NEW, statesEnum.NEED_UPDATE, statesEnum.INSTALLED]
 
@@ -175,7 +176,7 @@ module.exports = {
       }
       return group
     } else {
-      console.log(`Invalid group: ${name}`)
+      display.error('Invalid group', name)
     }
   },
   /**

--- a/lib/models/group.js
+++ b/lib/models/group.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const _ = require('lodash')
+var _ = require('lodash')
 
-const packageHandler = require('./package')
-const stateHandler = require('./state')
-const statesEnum = stateHandler.statesEnum
-const display = require('../ui/display')
+var packageHandler = require('./package')
+var stateHandler = require('./state')
+var statesEnum = stateHandler.statesEnum
+var display = require('../ui/display')
 
-const STATES_BY_PRIORITY = [statesEnum.NEW, statesEnum.NEED_UPDATE, statesEnum.INSTALLED]
+var STATES_BY_PRIORITY = [statesEnum.NEW, statesEnum.NEED_UPDATE, statesEnum.INSTALLED]
 
 module.exports = {
   /**
@@ -16,18 +16,19 @@ module.exports = {
    * @param {object} group the group
    * @returns {string} a group to string
    */
-  toString (name, group) {
+  toString: function (name, group) {
     if (name && group) {
-      let toString = ''
+      var toString = ''
+      var pkgToStr
       if (group.isGroup) {
-        const packages = this.getPkgsBy(group, packageHandler.toString)
+        var packages = this.getPkgsBy(group, packageHandler.toString)
         if (packages) {
-          const pkgToStr = (packages && !_.isEmpty(packages)) ? '(' + packages.join(', ') + ')' : ''
+          pkgToStr = (packages && !_.isEmpty(packages)) ? '(' + packages.join(', ') + ')' : ''
           toString = name + ' ' + pkgToStr
         }
       } else {
-        const pkg = this._getPkgs(group)[name]
-        const pkgToStr = packageHandler.toString(name, pkg)
+        var pkg = this._getPkgs(group)[name]
+        pkgToStr = packageHandler.toString(name, pkg)
         if (pkgToStr) {
           toString = pkgToStr
         }
@@ -42,11 +43,11 @@ module.exports = {
    * @param {function} getPackageFct a function that will be called for every packages in the group
    * @returns {array} a list of all the packages in the group
    */
-  getPkgsBy (group, getPackageFct) {
-    let packages = []
-    let groupPkgs = this._getPkgs(group)
-    for (let name in groupPkgs) {
-      const pkg = getPackageFct(name, groupPkgs[name])
+  getPkgsBy: function (group, getPackageFct) {
+    var packages = []
+    var groupPkgs = this._getPkgs(group)
+    for (var name in groupPkgs) {
+      var pkg = getPackageFct(name, groupPkgs[name])
       if (pkg) {
         packages.push(pkg)
       }
@@ -58,7 +59,7 @@ module.exports = {
    * @param {oject} group a group
    * @returns {object} all the packages
    */
-  _getPkgs (group) {
+  _getPkgs: function (group) {
     if (group && group.packages) {
       return group.packages
     }
@@ -68,12 +69,12 @@ module.exports = {
    * @param {object} groups the groups
    * @returns {array} an object containing all the package names
    */
-  getPackageNames (groups) {
-    let packageNames = []
-    for (let groupName in groups) {
-      const group = groups[groupName]
+  getPackageNames: function (groups) {
+    var packageNames = []
+    for (var groupName in groups) {
+      var group = groups[groupName]
 
-      const pkgs = this.getPkgsBy(group, packageHandler.getPackageObj)
+      var pkgs = this.getPkgsBy(group, packageHandler.getPackageObj)
 
       packageNames = packageNames.concat(pkgs.map(function (pkg) { return pkg.name }))
     }
@@ -85,7 +86,7 @@ module.exports = {
    * @param {object} pkgs the packages of the group
    * @returns {boolean} true if is a valid group and false otherwise
    */
-  _isValid (pkgs) {
+  _isValid: function (pkgs) {
     return pkgs && !_.isEmpty(pkgs)
   },
   /**
@@ -96,22 +97,22 @@ module.exports = {
    * @param {boolean} isMandatory true is the groups are mandatory and false otherwise
    * @returns {object} the groups of packages
    */
-  createGroups (groupsNPkgs, isThisAddonInstalled, isMandatory) {
-    let groups = {}
-    for (let groupNPkgName in groupsNPkgs) {
-      const groupsNPkg = groupsNPkgs[groupNPkgName]
+  createGroups: function (groupsNPkgs, isThisAddonInstalled, isMandatory) {
+    var groups = {}
+    for (var groupNPkgName in groupsNPkgs) {
+      var groupsNPkg = groupsNPkgs[groupNPkgName]
 
-      let packages = {}
-      let isGroup = this._isGroup(groupsNPkg)
+      var packages = {}
+      var isGroup = this._isGroup(groupsNPkg)
       if (isGroup) {
         packages = this._getPkgs(groupsNPkg)
       } else {
         packages[groupNPkgName] = groupsNPkg
       }
 
-      let pkgs = packageHandler.createPkgs(packages)
+      var pkgs = packageHandler.createPkgs(packages)
 
-      const group = this._create(groupNPkgName, pkgs, isGroup, isThisAddonInstalled, isMandatory)
+      var group = this._create(groupNPkgName, pkgs, isGroup, isThisAddonInstalled, isMandatory)
       if (group) {
         groups[groupNPkgName] = group
       }
@@ -128,22 +129,22 @@ module.exports = {
    * @param {boolean} isMandatory true is the groups are mandatory and false otherwise
    * @returns {object} the groups of packages
    */
-  createRequestedGroups (requestedGroupsNPkgs, existingPkgs, isThisAddonInstalled, isMandatory) {
-    let groups = {}
-    for (let groupNPkgName in requestedGroupsNPkgs) {
-      const requestGroupNPkg = requestedGroupsNPkgs[groupNPkgName]
+  createRequestedGroups: function (requestedGroupsNPkgs, existingPkgs, isThisAddonInstalled, isMandatory) {
+    var groups = {}
+    for (var groupNPkgName in requestedGroupsNPkgs) {
+      var requestGroupNPkg = requestedGroupsNPkgs[groupNPkgName]
 
-      let requestedPkgs = {}
-      let isGroup = this._isGroup(requestGroupNPkg)
+      var requestedPkgs = {}
+      var isGroup = this._isGroup(requestGroupNPkg)
       if (isGroup) {
         requestedPkgs = this._getPkgs(requestGroupNPkg)
       } else {
         requestedPkgs[groupNPkgName] = requestGroupNPkg
       }
 
-      let pkgs = packageHandler.createRequestedPkgs(requestedPkgs, existingPkgs)
+      var pkgs = packageHandler.createRequestedPkgs(requestedPkgs, existingPkgs)
 
-      const group = this._create(groupNPkgName, pkgs, isGroup, isThisAddonInstalled, isMandatory)
+      var group = this._create(groupNPkgName, pkgs, isGroup, isThisAddonInstalled, isMandatory)
       if (group) {
         groups[groupNPkgName] = group
       }
@@ -164,9 +165,9 @@ module.exports = {
    * @param {boolean} isMandatory true is the group are mandatory and false otherwise
    * @returns {object} a group
    */
-  _create (name, packages, isGroup, isThisAddonInstalled, isMandatory) {
+  _create: function (name, packages, isGroup, isThisAddonInstalled, isMandatory) {
     if (this._isValid(packages)) {
-      let group = {
+      var group = {
         name: name,
         state: this._getState(packages),
         packages: packages,
@@ -184,14 +185,14 @@ module.exports = {
    * @param {object} packages all the packages of a group
    * @returns {string} the state of the group
    */
-  _getState (packages) {
-    let nbPackages = 0
-    let states = {}
-    for (let name in packages) {
+  _getState: function (packages) {
+    var nbPackages = 0
+    var states = {}
+    for (var name in packages) {
       // Count the number of packages
       nbPackages++
       // Count the number of packages in each state
-      const pkg = packages[name]
+      var pkg = packages[name]
       if (!states[pkg.state]) {
         states[pkg.state] = 0
       }
@@ -200,7 +201,7 @@ module.exports = {
 
     // If all the packages are in a specific state the group will have that
     // state otherwise it will be in the NEED_UPDATE state
-    for (let state of STATES_BY_PRIORITY) {
+    for (var state of STATES_BY_PRIORITY) {
       if (states[state] && states[state] === nbPackages) {
         return state
       }
@@ -212,7 +213,7 @@ module.exports = {
    * @param {oject} group a group
    * @returns {boolean} true if it's a group and false otherwise.
    */
-  _isGroup (group) {
+  _isGroup: function (group) {
     return this._getPkgs(group) !== undefined
   }
 }

--- a/lib/models/group.js
+++ b/lib/models/group.js
@@ -5,7 +5,6 @@ const _ = require('lodash')
 const packageHandler = require('./package')
 const stateHandler = require('./state')
 const statesEnum = stateHandler.statesEnum
-const objUtil = require('../../lib/utils/obj')
 
 const STATES_BY_PRIORITY = [statesEnum.NEW, statesEnum.NEED_UPDATE, statesEnum.INSTALLED]
 
@@ -18,32 +17,35 @@ module.exports = {
    */
   toString (name, group) {
     if (name && group) {
+      let toString = ''
       if (group.isGroup) {
         const packages = this.getPkgsBy(group, packageHandler.toString)
         if (packages) {
           const pkgToStr = (packages && !_.isEmpty(packages)) ? `(${packages.join(', ')})` : ''
-          return `${name} ${pkgToStr}`
+          toString = `${name} ${pkgToStr}`
         }
       } else {
         const pkg = this._getPkgs(group)[name]
         const pkgToStr = packageHandler.toString(name, pkg)
         if (pkgToStr) {
-          return `${pkgToStr}`
+          toString = `${pkgToStr}`
         }
       }
+
+      return toString
     }
   },
   /**
    * Get all the packages for a group and apply a specific function to all those packages.
    * @param {oject} group a group
-   * @param {function} getPackage a function that will be called for every packages in the group
+   * @param {function} getPackageFct a function that will be called for every packages in the group
    * @returns {array} a list of all the packages in the group
    */
-  getPkgsBy (group, getPackage) {
+  getPkgsBy (group, getPackageFct) {
     let packages = []
     let groupPkgs = this._getPkgs(group)
     for (let name in groupPkgs) {
-      const pkg = getPackage(name, groupPkgs[name])
+      const pkg = getPackageFct(name, groupPkgs[name])
       if (pkg) {
         packages.push(pkg)
       }
@@ -61,19 +63,21 @@ module.exports = {
     }
   },
   /**
-   * Get the packages for groups.
+   * Get a list of the name of the packages for each group.
    * @param {object} groups the groups
-   * @returns {object} an object containing all the packages
+   * @returns {array} an object containing all the package names
    */
-  getPackages (groups) {
-    let packages = {}
+  getPackageNames (groups) {
+    let packageNames = []
     for (let groupName in groups) {
       const group = groups[groupName]
 
       const pkgs = this.getPkgsBy(group, packageHandler.getPackageObj)
-      packages = objUtil.merge([packages, pkgs])
+
+      packageNames = packageNames.concat(pkgs.map((pkg) => { return pkg.name }))
     }
-    return packages
+
+    return packageNames
   },
   /**
    * Returns true if is a valid group and false otherwise.

--- a/lib/models/group.js
+++ b/lib/models/group.js
@@ -37,6 +37,7 @@ module.exports = {
       return toString
     }
   },
+
   /**
    * Get all the packages for a group and apply a specific function to all those packages.
    * @param {oject} group a group
@@ -54,6 +55,7 @@ module.exports = {
     }
     return packages
   },
+
   /**
    * Get the packages form a group
    * @param {oject} group a group
@@ -64,6 +66,7 @@ module.exports = {
       return group.packages
     }
   },
+
   /**
    * Get a list of the name of the packages for each group.
    * @param {object} groups the groups
@@ -81,6 +84,7 @@ module.exports = {
 
     return packageNames
   },
+
   /**
    * Returns true if is a valid group and false otherwise.
    * @param {object} pkgs the packages of the group
@@ -89,6 +93,7 @@ module.exports = {
   _isValid: function (pkgs) {
     return pkgs && !_.isEmpty(pkgs)
   },
+
   /**
    * Create the groups of packages.
    * Note: This method is returning single packages as groups to simplify the handling.
@@ -120,6 +125,7 @@ module.exports = {
 
     return groups
   },
+
   /**
    * Create the groups of packages based on the requested and existing packages.
    * Note: This method is returning single packages as groups to simplify the handling.
@@ -152,6 +158,7 @@ module.exports = {
 
     return groups
   },
+
   /**
    * Create a group.
    * @param {string} name the name of the group
@@ -180,6 +187,7 @@ module.exports = {
       display.error('Invalid group', name)
     }
   },
+
   /**
    * Get the state of the group.
    * @param {object} packages all the packages of a group
@@ -208,6 +216,7 @@ module.exports = {
     }
     return statesEnum.NEED_UPDATE
   },
+
   /**
    * Returns true if it's a group and false otherwise.
    * @param {oject} group a group
@@ -215,5 +224,21 @@ module.exports = {
    */
   _isGroup: function (group) {
     return this._getPkgs(group) !== undefined
+  },
+
+  /**
+   * Returns true if any of the packages is a downgrade in the group and false otherwise.
+   * @param {object} group the group
+   * @returns {boolean} true if any of the packages is a downgrade in the group and false otherwise
+   */
+  isDowngrade: function (group) {
+    var isDowngrade = false
+
+    var packages = this._getPkgs(group)
+    for (var pkgName in packages) {
+      var pkg = packages[pkgName]
+      isDowngrade = isDowngrade || packageHandler.isDowngrade(pkg)
+    }
+    return isDowngrade
   }
 }

--- a/lib/models/group.js
+++ b/lib/models/group.js
@@ -184,21 +184,27 @@ module.exports = {
    * @returns {string} the state of the group
    */
   _getState (packages) {
+    let nbPackages = 0
     let states = {}
-
     for (let name in packages) {
+      // Count the number of packages
+      nbPackages++
+      // Count the number of packages in each state
       const pkg = packages[name]
-      states[pkg.state] = {}
+      if (!states[pkg.state]) {
+        states[pkg.state] = 0
+      }
+      states[pkg.state]++
     }
 
-    // Get the group state based on the priority of the states
-    // Ex. If there is one of the package that is manadatory then
-    // the group is considered as mandatory
+    // If all the packages are in a specific state the group will have that
+    // state otherwise it will be in the NEED_UPDATE state
     for (let state of STATES_BY_PRIORITY) {
-      if (states[state]) {
+      if (states[state] && states[state] === nbPackages) {
         return state
       }
     }
+    return statesEnum.NEED_UPDATE
   },
   /**
    * Returns true if it's a group and false otherwise.

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const stateHandler = require('./state')
-const statesEnum = stateHandler.statesEnum
-const display = require('../ui/display')
+var stateHandler = require('./state')
+var statesEnum = stateHandler.statesEnum
+var display = require('../ui/display')
 
-const PKG_TARGET_REGEX = /([0-9]*)\.([0-9]*)\.([0-9]*)/
+var PKG_TARGET_REGEX = /([0-9]*)\.([0-9]*)\.([0-9]*)/
 
 module.exports = {
   /**
@@ -13,7 +13,7 @@ module.exports = {
    * @param {object} pkg the package information
    * @returns {string} the package to string
    */
-  toString (name, pkg) {
+  toString: function (name, pkg) {
     return name + '@' + (pkg.target || pkg.installedTarget)
   },
   /**
@@ -23,7 +23,7 @@ module.exports = {
    * @param {object} requestedTarget the requested target
    * @returns {object} a package
    */
-  _create (name, currentTarget, requestedTarget) {
+  _create: function (name, currentTarget, requestedTarget) {
     if (this._isValid(name, currentTarget, requestedTarget)) {
       return {
         target: requestedTarget,
@@ -39,12 +39,12 @@ module.exports = {
    * @param {object} packages all the packages
    * @returns {object} all the packages
    */
-  createPkgs (packages) {
-    let pkgs = {}
-    for (let name in packages) {
-      const target = packages[name]
+  createPkgs: function (packages) {
+    var pkgs = {}
+    for (var name in packages) {
+      var target = packages[name]
 
-      const pkg = this._create(name, target)
+      var pkg = this._create(name, target)
       if (pkg) {
         pkgs[name] = pkg
       }
@@ -57,13 +57,13 @@ module.exports = {
    * @param {object} existingPkgs all the existing packags
    * @returns {object} all the packages
    */
-  createRequestedPkgs (packages, existingPkgs) {
-    let pkgs = {}
-    for (let name in packages) {
-      const requestedTarget = packages[name]
-      const currentTarget = existingPkgs[name]
+  createRequestedPkgs: function (packages, existingPkgs) {
+    var pkgs = {}
+    for (var name in packages) {
+      var requestedTarget = packages[name]
+      var currentTarget = existingPkgs[name]
 
-      const pkg = this._create(name, currentTarget, requestedTarget)
+      var pkg = this._create(name, currentTarget, requestedTarget)
       if (pkg) {
         pkgs[name] = pkg
       }
@@ -76,8 +76,8 @@ module.exports = {
    * @param {string} requestedTarget the requested target of the package
    * @returns {string} the state of the package
    */
-  _getState (currentTarget, requestedTarget) {
-    let state
+  _getState: function (currentTarget, requestedTarget) {
+    var state
     if (requestedTarget === undefined) {
       state = statesEnum.INSTALLED
     } else {
@@ -100,10 +100,10 @@ module.exports = {
    * @param {string} requestedTarget the requested target of the package
    * @returns {boolean} true if the requestedTarget is installed and false otherwise
    */
-  isInstalled (currentTarget, requestedTarget) {
+  isInstalled: function (currentTarget, requestedTarget) {
     if (requestedTarget && currentTarget) {
-      const dct = this.getDecomposedTarget(currentTarget)
-      const drt = this.getDecomposedTarget(requestedTarget)
+      var dct = this.getDecomposedTarget(currentTarget)
+      var drt = this.getDecomposedTarget(requestedTarget)
       return dct.major > drt.major ||
              dct.major === drt.major && dct.minor > drt.minor ||
              dct.major === drt.major && dct.minor === drt.minor && dct.patch >= drt.patch
@@ -115,10 +115,14 @@ module.exports = {
    * @param {string} target package target
    * @returns {object} decomposed target (major, minor, patch)
    */
-  getDecomposedTarget (target) {
+  getDecomposedTarget: function (target) {
     var regularExpresion = PKG_TARGET_REGEX
     var match = regularExpresion.exec(target)
-    return {major: match[1], minor: match[2], patch: match[3]}
+    return {
+      major: match[1],
+      minor: match[2],
+      patch: match[3]
+    }
   },
   /**
    * Returns true if is a valid package and false otherwise.
@@ -127,7 +131,7 @@ module.exports = {
    * @param {string} requestedTarget the requested target of the package
    * @returns {boolean} true if is a valid package and false otherwise
    */
-  _isValid (name, currentTarget, requestedTarget) {
+  _isValid: function (name, currentTarget, requestedTarget) {
     return name && typeof name === 'string' &&
           ((currentTarget && typeof currentTarget === 'string') ||
           (requestedTarget && typeof requestedTarget === 'string'))
@@ -138,16 +142,22 @@ module.exports = {
    * @param {object} pkg the package information
    * @returns {object} the package object
    */
-  getPackageObj (name, pkg) {
-    return { name, target: pkg.target || pkg.installedTarget }
+  getPackageObj: function (name, pkg) {
+    return {
+      name: name,
+      target: pkg.target || pkg.installedTarget
+    }
   },
   /**
    * Get a package object from the package information object.
    * @param {object} pkgInfo the information of the package
    * @returns {object} the package object
    */
-  getPackageObjFromPkgInfo (pkgInfo) {
+  getPackageObjFromPkgInfo: function (pkgInfo) {
     console.log(pkgInfo)
-    return { name: pkgInfo.name, target: pkgInfo.version }
+    return {
+      name: pkgInfo.name,
+      target: pkgInfo.version
+    }
   }
 }

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -2,6 +2,7 @@
 
 const stateHandler = require('./state')
 const statesEnum = stateHandler.statesEnum
+const display = require('../ui/display')
 
 const PKG_TARGET_REGEX = /([0-9]*)\.([0-9]*)\.([0-9]*)/
 
@@ -30,7 +31,7 @@ module.exports = {
         state: this._getState(currentTarget, requestedTarget)
       }
     } else {
-      console.log(`Invalid package: ${name}`)
+      display.error('Invalid package', name)
     }
   },
   /**

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -76,7 +76,6 @@ module.exports = {
    * @returns {string} the state of the package
    */
   _getState (currentTarget, requestedTarget) {
-    // TODO do not request an update if the package version is already >= (consider as already installed)
     let state
     if (requestedTarget === undefined) {
       state = statesEnum.INSTALLED

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -139,5 +139,14 @@ module.exports = {
    */
   getPackageObj (name, pkg) {
     return { name, target: pkg.target || pkg.installedTarget }
+  },
+  /**
+   * Get a package object from the package information object.
+   * @param {object} pkgInfo the information of the package
+   * @returns {object} the package object
+   */
+  getPackageObjFromPkgInfo (pkgInfo) {
+    console.log(pkgInfo)
+    return { name: pkgInfo.name, target: pkgInfo.version }
   }
 }

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -16,6 +16,7 @@ module.exports = {
   toString: function (name, pkg) {
     return name + '@' + (pkg.target || pkg.installedTarget)
   },
+
   /**
    * Create a package.
    * @param {string} name the name of the package
@@ -34,6 +35,7 @@ module.exports = {
       display.error('Invalid package', name)
     }
   },
+
   /**
    * Create packages.
    * @param {object} packages all the packages
@@ -51,6 +53,7 @@ module.exports = {
     }
     return pkgs
   },
+
   /**
    * Create packages.
    * @param {object} packages all requested the packages
@@ -70,6 +73,7 @@ module.exports = {
     }
     return pkgs
   },
+
   /**
    * Get the state of a package.
    * @param {string} currentTarget the current target of the package
@@ -94,6 +98,7 @@ module.exports = {
 
     return state
   },
+
   /**
    * Returns true if the requestedTarget is installed and false otherwise.
    * @param {string} currentTarget the current target of the package
@@ -101,15 +106,16 @@ module.exports = {
    * @returns {boolean} true if the requestedTarget is installed and false otherwise
    */
   isInstalled: function (currentTarget, requestedTarget) {
+    var dct = this.getDecomposedTarget(currentTarget)
+    var drt = this.getDecomposedTarget(requestedTarget)
     if (requestedTarget && currentTarget) {
-      var dct = this.getDecomposedTarget(currentTarget)
-      var drt = this.getDecomposedTarget(requestedTarget)
       return dct.major > drt.major ||
              dct.major === drt.major && dct.minor > drt.minor ||
              dct.major === drt.major && dct.minor === drt.minor && dct.patch >= drt.patch
     }
     return false
   },
+
   /**
    * Get the decomposed package target (major, minor, patch).
    * @param {string} target package target
@@ -124,6 +130,7 @@ module.exports = {
       patch: match[3]
     }
   },
+
   /**
    * Returns true if is a valid package and false otherwise.
    * @param {string} name the name of the package
@@ -136,6 +143,7 @@ module.exports = {
           ((currentTarget && typeof currentTarget === 'string') ||
           (requestedTarget && typeof requestedTarget === 'string'))
   },
+
   /**
    * Get a package object.
    * @param {string} name the name of the package
@@ -148,6 +156,7 @@ module.exports = {
       target: pkg.target || pkg.installedTarget
     }
   },
+
   /**
    * Get a package object from the package information object.
    * @param {object} pkgInfo the information of the package
@@ -159,5 +168,25 @@ module.exports = {
       name: pkgInfo.name,
       target: pkgInfo.version
     }
+  },
+
+  /**
+   * Returns true if the package is a downgrade and false otherwise.
+   * @param {object} pkg the package
+   * @returns {boolean} true if the package is a downgrade and false otherwise.
+   */
+  isDowngrade: function (pkg) {
+    if (pkg) {
+      var requestedTarget = pkg.target
+      var currentTarget = pkg.installedTarget
+      if (requestedTarget && currentTarget) {
+        var dct = this.getDecomposedTarget(currentTarget)
+        var drt = this.getDecomposedTarget(requestedTarget)
+        return dct.major > drt.major ||
+          dct.major === drt.major && dct.minor > drt.minor ||
+          dct.major === drt.major && dct.minor === drt.minor && dct.patch > drt.patch
+      }
+    }
+    return false
   }
 }

--- a/lib/models/state.js
+++ b/lib/models/state.js
@@ -1,3 +1,5 @@
+'use strict'
+
 module.exports = {
   /**
    * The possible values for a state

--- a/lib/ui/display.js
+++ b/lib/ui/display.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var chalk = require('chalk')
-'use strict'
+var figures = require('figures')
 
 var Spinner = require('cli-spinner').Spinner
 
@@ -14,6 +14,7 @@ module.exports = {
   error: function (title, message) {
     console.log('  ' + chalk.red(title) + ' ' + message)
   },
+
   /**
    * Display a title.
    * @param {string} title the title
@@ -21,6 +22,7 @@ module.exports = {
   title: function (title) {
     console.log(chalk.green(title))
   },
+
   /**
    * Display the message
    * @param {string} message the message to display
@@ -28,12 +30,23 @@ module.exports = {
   message: function (message) {
     console.log('  ' + message)
   },
+
   /**
    * Display a carriage return.
    */
   carriageReturn: function () {
     console.log('')
   },
+
+  /**
+   * Get a warning message.
+   * @param {string} message a message
+   * @returns {string} formatted message
+   */
+  getWarning: function (message) {
+    return chalk.yellow(figures.warning + ' ' + message)
+  },
+
   /**
    * Get a spinner
    * @param {string} message the message that will be display next to the spinner

--- a/lib/ui/display.js
+++ b/lib/ui/display.js
@@ -10,7 +10,7 @@ module.exports = {
    * @param {string} message the message
    */
   error (title, message) {
-    console.log(`   ${chalk.red(title)} ${message}`)
+    console.log(`  ${chalk.red(title)} ${message}`)
   },
   /**
    * Display a title.
@@ -24,7 +24,7 @@ module.exports = {
    * @param {string} message the message to display
    */
   message (message) {
-    console.log(`   ${message}`)
+    console.log(`  ${message}`)
   },
   /**
    * Display a carriage return.
@@ -40,7 +40,6 @@ module.exports = {
   getSpinner (message) {
     let spinner = new Spinner(message)
     spinner.setSpinnerString(18)
-    spinner.start()
     return spinner
   }
 }

--- a/lib/ui/display.js
+++ b/lib/ui/display.js
@@ -1,7 +1,9 @@
 'use strict'
 
-const chalk = require('chalk')
-const Spinner = require('cli-spinner').Spinner
+var chalk = require('chalk')
+'use strict'
+
+var Spinner = require('cli-spinner').Spinner
 
 module.exports = {
   /**
@@ -9,27 +11,27 @@ module.exports = {
    * @param {string} title title of the message
    * @param {string} message the message
    */
-  error (title, message) {
+  error: function (title, message) {
     console.log('  ' + chalk.red(title) + ' ' + message)
   },
   /**
    * Display a title.
    * @param {string} title the title
    */
-  title (title) {
+  title: function (title) {
     console.log(chalk.green(title))
   },
   /**
    * Display the message
    * @param {string} message the message to display
    */
-  message (message) {
+  message: function (message) {
     console.log('  ' + message)
   },
   /**
    * Display a carriage return.
    */
-  carriageReturn () {
+  carriageReturn: function () {
     console.log('')
   },
   /**
@@ -37,8 +39,8 @@ module.exports = {
    * @param {string} message the message that will be display next to the spinner
    * @returns {Spinner} a spinner
    */
-  getSpinner (message) {
-    let spinner = new Spinner(message)
+  getSpinner: function (message) {
+    var spinner = new Spinner(message)
     spinner.setSpinnerString(18)
     return spinner
   }

--- a/lib/ui/display.js
+++ b/lib/ui/display.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const chalk = require('chalk')
+const Spinner = require('cli-spinner').Spinner
+
+module.exports = {
+  /**
+   * Display an error message.
+   * @param {string} title title of the message
+   * @param {string} message the message
+   */
+  error (title, message) {
+    console.log(`   ${chalk.red(title)} ${message}`)
+  },
+  /**
+   * Display a title.
+   * @param {string} title the title
+   */
+  title (title) {
+    console.log(chalk.green(title))
+  },
+  /**
+   * Display the message
+   * @param {string} message the message to display
+   */
+  message (message) {
+    console.log(`   ${message}`)
+  },
+  /**
+   * Display a carriage return.
+   */
+  carriageReturn () {
+    console.log('')
+  },
+  /**
+   * Get a spinner
+   * @param {string} message the message that will be display next to the spinner
+   * @returns {Spinner} a spinner
+   */
+  getSpinner (message) {
+    let spinner = new Spinner(message)
+    spinner.setSpinnerString(18)
+    spinner.start()
+    return spinner
+  }
+}

--- a/lib/ui/display.js
+++ b/lib/ui/display.js
@@ -10,7 +10,7 @@ module.exports = {
    * @param {string} message the message
    */
   error (title, message) {
-    console.log(`  ${chalk.red(title)} ${message}`)
+    console.log('  ' + chalk.red(title) + ' ' + message)
   },
   /**
    * Display a title.
@@ -24,7 +24,7 @@ module.exports = {
    * @param {string} message the message to display
    */
   message (message) {
-    console.log(`  ${message}`)
+    console.log('  ' + message)
   },
   /**
    * Display a carriage return.

--- a/lib/ui/user-input.js
+++ b/lib/ui/user-input.js
@@ -25,6 +25,7 @@ module.exports = {
 
     return choices
   },
+
   /**
    * Get a question.
    * @param {object} question the question
@@ -45,6 +46,7 @@ module.exports = {
       return questionWithChoices
     }
   },
+
   /**
    * Get a prompt to ask questions to the user.
    * @param {object} context the current context
@@ -56,6 +58,7 @@ module.exports = {
       return context.ui.prompt(questions)
     }
   },
+
   /**
    * Get the user input for the choices
    * @param {object} context the current context

--- a/lib/ui/user-input.js
+++ b/lib/ui/user-input.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const _ = require('lodash')
+var _ = require('lodash')
 
 module.exports = {
   /**
@@ -10,14 +10,14 @@ module.exports = {
    * @param {array} choicesSelectedPreviously the choices that were selected previously
    * @returns {array} all the choices
    */
-  getChoices (entities, getChoiceForEntityFct, choicesSelectedPreviously) {
-    let choices = []
+  getChoices: function (entities, getChoiceForEntityFct, choicesSelectedPreviously) {
+    var choices = []
 
     if (entities && getChoiceForEntityFct) {
-      for (let entityId in entities) {
-        const entity = entities[entityId]
+      for (var entityId in entities) {
+        var entity = entities[entityId]
 
-        const wasChoiceSelectedPreviously =
+        var wasChoiceSelectedPreviously =
           (choicesSelectedPreviously === undefined) ? undefined : choicesSelectedPreviously.indexOf(entityId) > -1
         choices.push(getChoiceForEntityFct(entityId, entity, wasChoiceSelectedPreviously))
       }
@@ -31,9 +31,9 @@ module.exports = {
    * @param {array} choices a list of the choices
    * @returns {object} the user input
    */
-  _getQuestion (question, choices) {
+  _getQuestion: function (question, choices) {
     if (question && question.type && question.name && question.message && choices) {
-      let questionWithChoices = {
+      var questionWithChoices = {
         type: question.type,
         name: question.name,
         message: question.message
@@ -51,7 +51,7 @@ module.exports = {
    * @param {array} questions a list of the questions to ask to the user
    * @returns {Promise} the promise which will return the user inputs once it's resolved
    */
-  _promptUser (context, questions) {
+  _promptUser: function (context, questions) {
     if (context && context.ui) {
       return context.ui.prompt(questions)
     }
@@ -63,8 +63,8 @@ module.exports = {
    * @param {object} choices the choices for the question
    * @returns {Promise} the promise which will return the user inputs once it's resolved
    */
-  getUserInputForChoice (context, question, choices) {
-    let questionWithChoices
+  getUserInputForChoice: function (context, question, choices) {
+    var questionWithChoices
     if (choices) {
       questionWithChoices = this._getQuestion(question, choices)
     }

--- a/lib/ui/user-input.js
+++ b/lib/ui/user-input.js
@@ -16,7 +16,9 @@ module.exports = {
     if (entities && getChoiceForEntityFct) {
       for (let entityId in entities) {
         const entity = entities[entityId]
-        const wasChoiceSelectedPreviously = choicesSelectedPreviously.indexOf(entityId) > -1
+
+        const wasChoiceSelectedPreviously =
+          (choicesSelectedPreviously === undefined) ? undefined : choicesSelectedPreviously.indexOf(entityId) > -1
         choices.push(getChoiceForEntityFct(entityId, entity, wasChoiceSelectedPreviously))
       }
     }

--- a/lib/utils/external-app-packages.js
+++ b/lib/utils/external-app-packages.js
@@ -1,4 +1,6 @@
-const THIS_ADDON_NAME = 'ember-frost-lts'
+'use strict'
+
+var THIS_ADDON_NAME = 'ember-frost-lts'
 
 module.exports = {
   /**
@@ -6,7 +8,7 @@ module.exports = {
    * @param {object} options all the options
    * @returns {object} the existing packages
    */
-  getExistingPkgs (options) {
+  getExistingPkgs: function (options) {
     return options.project.pkg.devDependencies
   },
   /**
@@ -14,7 +16,7 @@ module.exports = {
    * @param {object} options all the options
    * @returns {boolean} true if this addon is installed in an external application/addon and false otherwise.
    */
-  isThisAddonInstalled (options) {
+  isThisAddonInstalled: function (options) {
     return this.getExistingPkgs(options)[THIS_ADDON_NAME] !== undefined
   }
 }

--- a/lib/utils/external-application.js
+++ b/lib/utils/external-application.js
@@ -9,8 +9,16 @@ module.exports = {
    * @returns {object} the existing packages
    */
   getExistingPkgs: function (options) {
-    return options.project.pkg.devDependencies
+    var existingPkgs = {}
+    var packages = options.project.pkg.devDependencies
+    for (var pkgName in packages) {
+      if (pkgName !== THIS_ADDON_NAME) {
+        existingPkgs[pkgName] = packages[pkgName]
+      }
+    }
+    return existingPkgs
   },
+
   /**
    * Returns true if this addon is installed in an external application/addon and false otherwise.
    * @param {object} options all the options

--- a/lib/utils/npm.js
+++ b/lib/utils/npm.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const spawn = require('child-process-promise').spawn
+const Promise = require('promise')
+
+module.exports = {
+  /**
+   * Run an npm command.
+   * @param {string} command the name of the npm command (view, install, unistall, etc.)
+   * @param {array} args a list of arguments
+   * @param {object} options the options of the command
+   * @returns {Promise} a promise that will return the command result once it's run
+   */
+  run (command, args, options) {
+    return spawn('npm', [command].concat(args), options || {})
+  },
+  /**
+   * Get the information about an npm package.
+   * @param {string} pkg the package name@target
+   * @returns {Promise} a promise that will return the information of an npm package in JSON format
+   */
+  view (pkg) {
+    return this.run('view', ['--json'].concat(pkg), {capture: ['stdout']})
+      .then((result) => {
+        return new Promise((resolve, reject) => {
+          resolve(JSON.parse(result.stdout.toString()))
+        })
+      })
+  }
+}

--- a/lib/utils/npm.js
+++ b/lib/utils/npm.js
@@ -21,8 +21,8 @@ module.exports = {
    */
   view (pkg) {
     return this.run('view', ['--json'].concat(pkg), {capture: ['stdout']})
-      .then((result) => {
-        return new Promise((resolve, reject) => {
+      .then(function (result) {
+        return new Promise(function (resolve, reject) {
           resolve(JSON.parse(result.stdout.toString()))
         })
       })

--- a/lib/utils/npm.js
+++ b/lib/utils/npm.js
@@ -14,6 +14,7 @@ module.exports = {
   run: function (command, args, options) {
     return spawn('npm', [command].concat(args), options || {})
   },
+
   /**
    * Get the information about an npm package.
    * @param {string} pkg the package name@target

--- a/lib/utils/npm.js
+++ b/lib/utils/npm.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const spawn = require('child-process-promise').spawn
-const Promise = require('promise')
+var spawn = require('child-process-promise').spawn
+var Promise = require('promise')
 
 module.exports = {
   /**
@@ -11,7 +11,7 @@ module.exports = {
    * @param {object} options the options of the command
    * @returns {Promise} a promise that will return the command result once it's run
    */
-  run (command, args, options) {
+  run: function (command, args, options) {
     return spawn('npm', [command].concat(args), options || {})
   },
   /**
@@ -19,7 +19,7 @@ module.exports = {
    * @param {string} pkg the package name@target
    * @returns {Promise} a promise that will return the information of an npm package in JSON format
    */
-  view (pkg) {
+  view: function (pkg) {
     return this.run('view', ['--json'].concat(pkg), {capture: ['stdout']})
       .then(function (result) {
         return new Promise(function (resolve, reject) {

--- a/lib/utils/obj.js
+++ b/lib/utils/obj.js
@@ -5,21 +5,16 @@ const _ = require('lodash')
 module.exports = {
   /**
    * Create a new object that will contain the content of all the objects.
-   * @param {array} objs a list of objects
+   * @param {array} sources the objects to merge
    * @returns {object} an object containing all the attributes of the objects passed in parameter
    */
-  merge (objs) {
-    if (objs && !_.isEmpty(objs)) {
-      let mergedObj = {}
-
-      for (let obj of objs) {
-        for (let key in obj) {
-          const value = obj[key]
-          mergedObj[key] = value
-        }
+  merge () {
+    let mergedObj = {}
+    _.mergeWith(mergedObj, ...arguments, function (objValue, srcValue) {
+      if (_.isArray(objValue)) {
+        return objValue.concat(srcValue)
       }
-
-      return mergedObj
-    }
+    })
+    return mergedObj
   }
 }

--- a/lib/utils/obj.js
+++ b/lib/utils/obj.js
@@ -1,20 +1,17 @@
 'use strict'
 
-const _ = require('lodash')
+var _ = require('lodash')
 
 module.exports = {
   /**
-   * Create a new object that will contain the content of all the objects.
-   * @param {array} sources the objects to merge
-   * @returns {object} an object containing all the attributes of the objects passed in parameter
+   * Merge arrays
+   * @param {array} objValue the objects to merge
+   * @param {array} srcValue the source objects
+   * @returns {array} merged arrays
    */
-  merge () {
-    let mergedObj = {}
-    _.mergeWith(mergedObj, ...arguments, function (objValue, srcValue) {
-      if (_.isArray(objValue)) {
-        return objValue.concat(srcValue)
-      }
-    })
-    return mergedObj
+  mergeArray: function (objValue, srcValue) {
+    if (_.isArray(objValue)) {
+      return objValue.concat(srcValue)
+    }
   }
 }

--- a/lib/utils/recommended-groups.js
+++ b/lib/utils/recommended-groups.js
@@ -31,6 +31,7 @@ module.exports = {
     }
     return ltsFilesContent
   },
+
   /**
    * Get the mandatory groups and packages requested.
    * @param {object} options all the options
@@ -43,6 +44,7 @@ module.exports = {
     }
     return {}
   },
+
   /**
    * Get the non mandatory groups and packages requested.
    * @param {object} options all the options

--- a/lib/utils/requested-packages.js
+++ b/lib/utils/requested-packages.js
@@ -16,7 +16,7 @@ module.exports = {
     let ltsFilesContent = {}
 
     let ltsFilePath = options.ltsFile
-    if (ltsFilePath.trim() !== '') {
+    if (ltsFilePath && ltsFilePath.trim() !== '') {
       ltsFilesContent = require(`../../${ltsFilePath}`)
     } else {
       const addonPackages = options.project.addonPackages

--- a/lib/utils/requested-packages.js
+++ b/lib/utils/requested-packages.js
@@ -1,7 +1,9 @@
 'use strict'
 
-const defaultLtsFile = require('../../lts.json')
+const _ =  require('lodash')
 
+const ADDON_LTS_KEYWORD = 'lts'
+const LTS_FILE_NAME = 'lts'
 const MANDATORY_KEY = 'mandatory'
 
 module.exports = {
@@ -10,14 +12,24 @@ module.exports = {
    * @param {object} options all the options
    * @returns {object} the content of the LTS file (groups and packages)
    */
-  // TODO: Check ember frost core icon packs
   _getLts (options) {
+    let ltsFilesContent = {}
+
     let ltsFilePath = options.ltsFile
-    let ltsFile = defaultLtsFile
     if (ltsFilePath.trim() !== '') {
-      ltsFile = require(`../../${ltsFilePath}`)
+      ltsFilesContent = require(`../../${ltsFilePath}`)
+    } else {
+      const addonPackages = options.project.addonPackages
+
+      for (let addonName in addonPackages) {
+        const addon = addonPackages[addonName]
+        if (addon.pkg.keywords.indexOf(ADDON_LTS_KEYWORD) > -1) {
+          const ltsFile = require(`${addon.path}/${LTS_FILE_NAME}.json`)
+          _.merge(ltsFilesContent, ltsFile)
+        }
+      }
     }
-    return ltsFile
+    return ltsFilesContent
   },
   /**
    * Get the mandatory groups and packages requested.

--- a/lib/utils/requested-packages.js
+++ b/lib/utils/requested-packages.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const _ = require('lodash')
+var _ = require('lodash')
 
-const ADDON_LTS_KEYWORD = 'lts'
-const LTS_FILE_NAME = 'lts'
-const MANDATORY_KEY = 'mandatory'
+var ADDON_LTS_KEYWORD = 'lts'
+var LTS_FILE_NAME = 'lts'
+var MANDATORY_KEY = 'mandatory'
 
 module.exports = {
   /**
@@ -12,19 +12,19 @@ module.exports = {
    * @param {object} options all the options
    * @returns {object} the content of the LTS file (groups and packages)
    */
-  _getLts (options) {
-    let ltsFilesContent = {}
+  _getLts: function (options) {
+    var ltsFilesContent = {}
 
-    let ltsFilePath = options.ltsFile
+    var ltsFilePath = options.ltsFile
     if (ltsFilePath && ltsFilePath.trim() !== '') {
       ltsFilesContent = require('../../' + ltsFilePath)
     } else {
-      const addonPackages = options.project.addonPackages
+      var addonPackages = options.project.addonPackages
 
-      for (let addonName in addonPackages) {
-        const addon = addonPackages[addonName]
+      for (var addonName in addonPackages) {
+        var addon = addonPackages[addonName]
         if (addon.pkg.keywords.indexOf(ADDON_LTS_KEYWORD) > -1) {
-          const ltsFile = require(addon.path + '/' + LTS_FILE_NAME + '.json')
+          var ltsFile = require(addon.path + '/' + LTS_FILE_NAME + '.json')
           _.merge(ltsFilesContent, ltsFile)
         }
       }
@@ -36,8 +36,8 @@ module.exports = {
    * @param {object} options all the options
    * @returns {object} an object containing all the mandatory groups and packages
    */
-  getMandatoryGroupsNPkgs (options) {
-    const lts = this._getLts(options)
+  getMandatoryGroupsNPkgs: function (options) {
+    var lts = this._getLts(options)
     if (lts && lts[MANDATORY_KEY]) {
       return lts[MANDATORY_KEY]
     }
@@ -48,12 +48,12 @@ module.exports = {
    * @param {object} options all the options
    * @returns {object} an object containing all the non mandatory groups and packages
    */
-  getOptionalGroupsNPkgs (options) {
-    const lts = this._getLts(options)
+  getOptionalGroupsNPkgs: function (options) {
+    var lts = this._getLts(options)
 
-    let groupsNPkgs = {}
+    var groupsNPkgs = {}
     if (lts) {
-      for (let key in lts) {
+      for (var key in lts) {
         if (key !== MANDATORY_KEY) {
           groupsNPkgs[key] = lts[key]
         }

--- a/lib/utils/requested-packages.js
+++ b/lib/utils/requested-packages.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const _ =  require('lodash')
+const _ = require('lodash')
 
 const ADDON_LTS_KEYWORD = 'lts'
 const LTS_FILE_NAME = 'lts'

--- a/lib/utils/requested-packages.js
+++ b/lib/utils/requested-packages.js
@@ -17,14 +17,14 @@ module.exports = {
 
     let ltsFilePath = options.ltsFile
     if (ltsFilePath && ltsFilePath.trim() !== '') {
-      ltsFilesContent = require(`../../${ltsFilePath}`)
+      ltsFilesContent = require('../../' + ltsFilePath)
     } else {
       const addonPackages = options.project.addonPackages
 
       for (let addonName in addonPackages) {
         const addon = addonPackages[addonName]
         if (addon.pkg.keywords.indexOf(ADDON_LTS_KEYWORD) > -1) {
-          const ltsFile = require(`${addon.path}/${LTS_FILE_NAME}.json`)
+          const ltsFile = require(addon.path + '/' + LTS_FILE_NAME + '.json')
           _.merge(ltsFilesContent, ltsFile)
         }
       }

--- a/lib/utils/requested-packages.js
+++ b/lib/utils/requested-packages.js
@@ -10,6 +10,7 @@ module.exports = {
    * @param {object} options all the options
    * @returns {object} the content of the LTS file (groups and packages)
    */
+  // TODO: Check ember frost core icon packs
   _getLts (options) {
     let ltsFilePath = options.ltsFile
     let ltsFile = defaultLtsFile

--- a/lts.json
+++ b/lts.json
@@ -23,7 +23,7 @@
   },
   "package3": {
     "packages": {
-      "lodash-es": "4.15.0"
+      "lodash": "4.15.0"
     }
   },
   "package4": {

--- a/lts.json
+++ b/lts.json
@@ -23,7 +23,7 @@
   },
   "package3": {
     "packages": {
-      "lodash": "4.15.0"
+      "lodash": "4.14.0"
     }
   },
   "package4": {

--- a/node-tests/blueprints/ember-frost-lts-test.js
+++ b/node-tests/blueprints/ember-frost-lts-test.js
@@ -21,18 +21,6 @@ const requireFromCLI = require('ember-cli-blueprint-test-helpers/lib/helpers/req
 const Blueprint = requireFromCLI('lib/models/blueprint')
 const MockUI = requireFromCLI('tests/helpers/mock-ui')
 
-/**
- * Expected behavior
- * - New packages
- *    - Accept or reject any changes
- *    - Show the diff. to tell what's new
- * - Already have the packages
- *    - Not on LTS
- *        - Handle like new packages
- *    - Already on an LTS
- *        - Automatically update to the latest the packages you already have
- *        - Show the user the packages you updated
- */
 describe('Acceptance: ember generate ember-frost-lts', function () {
   setupTestHooks(this)
 

--- a/node-tests/blueprints/ember-frost-lts-test.js
+++ b/node-tests/blueprints/ember-frost-lts-test.js
@@ -21,10 +21,35 @@ const requireFromCLI = require('ember-cli-blueprint-test-helpers/lib/helpers/req
 const Blueprint = requireFromCLI('lib/models/blueprint')
 const MockUI = requireFromCLI('tests/helpers/mock-ui')
 
+const otherPkgsToSelectByDefaylt = [
+  'broccoli-asset-rev',
+  'ember-ajax',
+  'ember-cli',
+  'ember-cli-app-version',
+  'ember-cli-babel',
+  'ember-cli-dependency-checker',
+  'ember-cli-htmlbars',
+  'ember-cli-htmlbars-inline-precompile',
+  'ember-cli-inject-live-reload',
+  'ember-cli-jshint',
+  'ember-cli-qunit',
+  'ember-cli-release',
+  'ember-cli-sri',
+  'ember-cli-test-loader',
+  'ember-cli-uglify',
+  'ember-data',
+  'ember-export-application-global',
+  'ember-load-initializers',
+  'ember-resolver',
+  'ember-welcome-page',
+  'loader.js',
+  'ember-frost-lts'
+]
+
 describe('Acceptance: ember generate ember-frost-lts', function () {
   setupTestHooks(this)
 
-  let prompt, packages
+  let prompt, packagesToInstall, packagesToUninstall
   beforeEach(function () {
     // Mock the UI prompt to avoid prompting during tests
     prompt = td.function()
@@ -32,15 +57,21 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
     // Mock the behavior on install to get the packages installed
     const installTaskRun = td.function()
-    td.when(installTaskRun(td.matchers.anything())).thenDo((task) => { packages = task.packages })
+    td.when(installTaskRun(td.matchers.anything())).thenDo((task) => { packagesToInstall = task.packages })
+
+    // Mock the behavior on uninstall to get the packages uninstall
+    const uninstallTaskRun = td.function()
+    td.when(uninstallTaskRun(td.matchers.anything())).thenDo((task) => { packagesToUninstall = task.packages })
 
     // Mock the behavior on addon-install
     const taskFor = td.function()
     td.when(taskFor('addon-install')).thenReturn({ run: installTaskRun })
+    td.when(taskFor('npm-uninstall')).thenReturn({ run: uninstallTaskRun })
 
     td.replace(Blueprint.prototype, 'taskFor', taskFor)
 
-    packages = null
+    packagesToInstall = null
+    packagesToUninstall = null
   })
 
   afterEach(function () {
@@ -50,25 +81,27 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
   it('No package to install (empty file)', function () {
     const args = ['ember-frost-lts', '--lts-file=node-tests/mock/empty-lts.json']
     td.when(prompt(td.matchers.anything())).thenResolve({
+      userInputOtherGroups: otherPkgsToSelectByDefaylt,
       confirmSelection: 'y'
     })
 
     return emberNew()
       .then(() => emberGenerate(args))
-      .then(() => expect(packages)
+      .then(() => expect(packagesToInstall)
         .to.be.eql(null))
   })
 
   it('Single package', function () {
     const args = ['ember-frost-lts', '--lts-file=node-tests/mock/single-package-lts.json']
     td.when(prompt(td.matchers.anything())).thenResolve({
-      userInputInstallPkgs: ['ember-prop-types'],
+      userInputRecommendGroups: ['ember-prop-types'],
+      userInputOtherGroups: otherPkgsToSelectByDefaylt,
       confirmSelection: 'y'
     })
 
     return emberNew()
       .then(() => emberGenerate(args))
-      .then(() => expect(packages)
+      .then(() => expect(packagesToInstall)
         .to.have.lengthOf(1)
         .to.contain('ember-prop-types@~0.2.0'))
   })
@@ -76,143 +109,193 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
   it('Single group', function () {
     const args = ['ember-frost-lts', '--lts-file=node-tests/mock/single-group-lts.json']
     td.when(prompt(td.matchers.anything())).thenResolve({
-      userInputInstallPkgs: ['package3'],
+      userInputRecommendGroups: ['package3'],
+      userInputOtherGroups: otherPkgsToSelectByDefaylt,
       confirmSelection: 'y'
     })
 
     return emberNew()
       .then(() => emberGenerate(args))
-      .then(() => expect(packages)
+      .then(() => expect(packagesToInstall)
         .to.have.lengthOf(1)
         .to.contain('my-package@0.2.0'))
   })
 
   describe('User request', function () {
+    let args
+    beforeEach(function () {
+      args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts.json']
+    })
+
     it('User request only 1 group', function () {
-      const args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts.json']
       td.when(prompt(td.matchers.anything())).thenResolve({
-        userInputInstallPkgs: ['package3'],
+        userInputRecommendGroups: ['package3'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
       return emberNew()
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
+        .then(() => expect(packagesToInstall)
           .to.have.lengthOf(1)
           .to.contain('my-package@0.2.0'))
     })
 
     it('User request only 1 package', function () {
-      const args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts.json']
       td.when(prompt(td.matchers.anything())).thenResolve({
-        userInputInstallPkgs: ['ember-prop-types'],
+        userInputRecommendGroups: ['ember-prop-types'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
       return emberNew()
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
+        .then(() => expect(packagesToInstall)
           .to.have.lengthOf(1)
           .to.contain('ember-prop-types@~0.2.0'))
     })
 
     it('User request everything', function () {
-      const args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts.json']
       td.when(prompt(td.matchers.anything())).thenResolve({
-        userInputInstallPkgs: ['package3', 'package4', 'ember-prop-types'],
+        userInputRecommendGroups: ['package3', 'package4', 'ember-prop-types'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
       return emberNew()
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
+        .then(() => expect(packagesToInstall)
           .to.have.lengthOf(4)
           .to.contain('my-package@0.2.0')
           .to.contain('ember-prop-types@~0.2.0')
           .to.contain('ember-frost-core@0.25.3')
           .to.contain('ember-d3@0.2.0'))
     })
+
+    it('User request install recommended package', function () {
+      td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputRecommendGroups: ['ember-prop-types'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
+        confirmSelection: 'y'
+      })
+
+      return emberNew()
+        .then(() => emberGenerate(args))
+        .then(() => expect(packagesToInstall)
+          .to.have.lengthOf(1)
+          .to.contain('ember-prop-types@~0.2.0'))
+    })
+
+    it('User request uninstall recommended package', function () {
+      td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
+        confirmSelection: 'y'
+      })
+
+      return emberNew()
+        .then(() => modifyPackages([
+          {name: 'ember-prop-types', version: '~0.2.0', dev: true} // installed
+        ]))
+        .then(() => emberGenerate(args))
+        .then(() => expect(packagesToInstall)
+          .to.be.eql(null))
+        .then(() => expect(packagesToUninstall)
+          .to.have.lengthOf(1)
+          .to.contain('ember-prop-types'))
+    })
+
+    it('User request install + uninstall recommended package', function () {
+      td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputRecommendGroups: ['ember-prop-types'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
+        confirmSelection: 'y'
+      })
+
+      return emberNew()
+        .then(() => modifyPackages([
+          {name: 'ember-d3', version: '0.2.0', dev: true},          // installed
+          {name: 'ember-frost-core', version: '0.25.3', dev: true}  // installed
+        ]))
+        .then(() => emberGenerate(args))
+        .then(() => expect(packagesToInstall)
+          .to.have.lengthOf(1)
+          .to.contain('ember-prop-types@~0.2.0'))
+        .then(() => expect(packagesToUninstall)
+          .to.have.lengthOf(2)
+          .to.contain('ember-d3')
+          .to.contain('ember-frost-core'))
+    })
+
+    it('User request uninstall other package', function () {
+      td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
+        confirmSelection: 'y'
+      })
+
+      return emberNew()
+        .then(() => modifyPackages([
+          {name: 'my-package1', version: '0.2.0', dev: true}   // installed
+        ]))
+        .then(() => emberGenerate(args))
+        .then(() => expect(packagesToInstall)
+          .to.be.eql(null))
+        .then(() => expect(packagesToUninstall)
+          .to.have.lengthOf(1)
+          .to.contain('my-package1'))
+    })
+
+    it('User request install + uninstall recommended package and unistall other package', function () {
+      td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputRecommendGroups: ['ember-prop-types'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
+        confirmSelection: 'y'
+      })
+
+      return emberNew()
+        .then(() => modifyPackages([
+          {name: 'ember-d3', version: '0.2.0', dev: true},            // installed
+          {name: 'ember-frost-core', version: '0.25.3', dev: true},   // installed
+          {name: 'my-package1', version: '0.2.0', dev: true}          // installed
+        ]))
+        .then(() => emberGenerate(args))
+        .then(() => expect(packagesToInstall)
+          .to.have.lengthOf(1)
+          .to.contain('ember-prop-types@~0.2.0'))
+        .then(() => expect(packagesToUninstall)
+          .to.have.lengthOf(3)
+          .to.contain('ember-d3')
+          .to.contain('ember-frost-core')
+          .to.contain('my-package1'))
+    })
   })
 
-  describe('Non LTS and LTS', function () {
+  describe('Recommended packages - Action based on selection', function () {
     let args
     beforeEach(function () {
       args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts.json']
     })
 
-    describe('Group', function () {
+    describe('Selected', function () {
       it('Group containing only new packages', function () {
         td.when(prompt(td.matchers.anything())).thenResolve({
-          userInputInstallPkgs: ['package3', 'package4'],
+          userInputRecommendGroups: ['package3', 'package4'],
+          userInputOtherGroups: otherPkgsToSelectByDefaylt,
           confirmSelection: 'y'
         })
 
         return emberNew()
           .then(() => emberGenerate(args))
-          .then(() => expect(packages)
+          .then(() => expect(packagesToInstall)
             .to.have.lengthOf(3)
             .to.contain('my-package@0.2.0')
             .to.contain('ember-d3@0.2.0')
             .to.contain('ember-frost-core@0.25.3'))
       })
 
-      it('Group containing packages already installed', function () {
-        td.when(prompt(td.matchers.anything())).thenResolve({
-          confirmSelection: 'y'
-        })
-
-        return emberNew()
-          .then(() => modifyPackages([
-            {name: 'my-package', version: '0.2.0', dev: true},        // installed
-            {name: 'ember-frost-core', version: '0.25.3', dev: true}, // installed
-            {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packages)
-            .to.have.eql(null))
-      })
-
-      it('Group containing package to update and new package', function () {
-        td.when(prompt(td.matchers.anything())).thenResolve({
-          userInputInstallPkgs: ['package4'],
-          confirmSelection: 'y'
-        })
-
-        return emberNew()
-          .then(() => modifyPackages([
-            {name: 'my-package', version: '0.2.0', dev: true},        // installed
-            {name: 'ember-frost-core', version: '0.25.2', dev: true}  // to update
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packages)
-            .to.have.lengthOf(2)
-            .to.contain('ember-d3@0.2.0')
-            .to.contain('ember-frost-core@0.25.3'))
-      })
-
-      it('Group containing package already installed and new package', function () {
-        td.when(prompt(td.matchers.anything())).thenResolve({
-          userInputInstallPkgs: ['package4'],
-          confirmSelection: 'y'
-        })
-
-        return emberNew()
-          .then(() => modifyPackages([
-            {name: 'my-package', version: '0.2.0', dev: true},        // installed
-            {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packages)
-            .to.have.lengthOf(2)
-            .to.contain('ember-d3@0.2.0')
-            .to.contain('ember-frost-core@0.25.3'))
-      })
-
       it('Group containing only packages to update', function () {
         td.when(prompt(td.matchers.anything())).thenResolve({
-          // Same test for LTS and non LTS because we need to mock this but those will be selected by default since we
-          // are on an LTS and that we already have those packages in our package.json
-          userInputInstallPkgs: ['package3', 'package4'],
+          userInputRecommendGroups: ['package3', 'package4'],
+          userInputOtherGroups: otherPkgsToSelectByDefaylt,
           confirmSelection: 'y'
         })
 
@@ -223,131 +306,199 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
             {name: 'ember-d3', version: '0.1.0', dev: true}           // to update
           ]))
           .then(() => emberGenerate(args))
-          .then(() => expect(packages)
+          .then(() => expect(packagesToInstall)
             .to.have.lengthOf(3)
             .to.contain('my-package@0.2.0')
             .to.contain('ember-d3@0.2.0')
             .to.contain('ember-frost-core@0.25.3'))
       })
 
-      it('Group containing package already installed and package to update', function () {
+      it('Group containing packages already installed', function () {
         td.when(prompt(td.matchers.anything())).thenResolve({
-          // Same test for LTS and non LTS because we need to mock this but those will be selected by default since we
-          // are on an LTS and that we already have those packages in our package.json
-          userInputInstallPkgs: ['package4'],
+          userInputRecommendGroups: ['package3', 'package4'],
+          userInputOtherGroups: otherPkgsToSelectByDefaylt,
           confirmSelection: 'y'
         })
 
         return emberNew()
           .then(() => modifyPackages([
             {name: 'my-package', version: '0.2.0', dev: true},        // installed
-            {name: 'ember-frost-core', version: '0.25.2', dev: true}, // to update
+            {name: 'ember-frost-core', version: '0.25.3', dev: true}, // installed
             {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
           ]))
           .then(() => emberGenerate(args))
-          .then(() => expect(packages)
-            .to.have.lengthOf(2)
+          .then(() => expect(packagesToInstall)
+            .to.have.lengthOf(3)
+            .to.contain('my-package@0.2.0')
             .to.contain('ember-d3@0.2.0')
             .to.contain('ember-frost-core@0.25.3'))
       })
     })
 
-    describe('Single packages', function () {
-      it('Packages already installed', function () {
+    describe('Not selected', function () {
+      it('Group containing only new packages', function () {
         td.when(prompt(td.matchers.anything())).thenResolve({
+          userInputOtherGroups: otherPkgsToSelectByDefaylt,
+          confirmSelection: 'y'
+        })
+
+        return emberNew()
+          .then(() => emberGenerate(args))
+          .then(() => expect(packagesToInstall)
+            .to.be.eql(null))
+      })
+
+      it('Group containing only packages to update', function () {
+        td.when(prompt(td.matchers.anything())).thenResolve({
+          userInputOtherGroups: otherPkgsToSelectByDefaylt,
           confirmSelection: 'y'
         })
 
         return emberNew()
           .then(() => modifyPackages([
-            {name: 'ember-prop-types', version: '~0.2.0', dev: true} // installed
+            {name: 'my-package', version: '0.1.0', dev: true},        // to update
+            {name: 'ember-frost-core', version: '0.25.2', dev: true}, // to update
+            {name: 'ember-d3', version: '0.1.0', dev: true}           // to update
           ]))
           .then(() => emberGenerate(args))
-          .then(() => expect(packages)
+          .then(() => expect(packagesToInstall)
+            .to.be.eql(null))
+      })
+
+      it('Group containing packages already installed', function () {
+        td.when(prompt(td.matchers.anything())).thenResolve({
+          userInputOtherGroups: otherPkgsToSelectByDefaylt,
+          confirmSelection: 'y'
+        })
+
+        return emberNew()
+          .then(() => modifyPackages([
+            {name: 'my-package', version: '0.2.0', dev: true},        // installed
+            {name: 'ember-frost-core', version: '0.25.3', dev: true}, // installed
+            {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
+          ]))
+          .then(() => emberGenerate(args))
+          .then(() => expect(packagesToInstall)
+            .to.be.eql(null))
+          .then(() => expect(packagesToUninstall)
+            .to.have.lengthOf(3)
+            .to.contain('my-package')
+            .to.contain('ember-d3')
+            .to.contain('ember-frost-core'))
+      })
+    })
+  })
+
+  describe('Other packages - Action based on selection', function () {
+    let args
+    beforeEach(function () {
+      args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts.json']
+    })
+
+    describe('Selected', function () {
+      it('Group containing packages already installed', function () {
+        console.log('before', otherPkgsToSelectByDefaylt)
+        const otherPkgsSelected = otherPkgsToSelectByDefaylt.concat(['my-package2'])
+        console.log('after', otherPkgsSelected)
+        td.when(prompt(td.matchers.anything())).thenResolve({
+          userInputOtherGroups: otherPkgsSelected,
+          confirmSelection: 'y'
+        })
+
+        return emberNew()
+          .then(() => modifyPackages([
+            {name: 'my-package2', version: '0.2.0', dev: true}        // installed
+          ]))
+          .then(() => emberGenerate(args))
+          .then(() => expect(packagesToUninstall)
             .to.be.eql(null))
       })
     })
 
-    it('Groups and single packages all installed', function () {
+    describe('Not selected', function () {
+      it('Group containing packages already installed', function () {
+        td.when(prompt(td.matchers.anything())).thenResolve({
+          userInputOtherGroups: otherPkgsToSelectByDefaylt,
+          confirmSelection: 'y'
+        })
+
+        return emberNew()
+          .then(() => modifyPackages([
+            {name: 'my-package', version: '0.2.0', dev: true}        // installed
+          ]))
+          .then(() => emberGenerate(args))
+          .then(() => expect(packagesToUninstall)
+            .to.have.lengthOf(1)
+            .to.contain('my-package'))
+      })
+    })
+  })
+
+  describe('Group with mixed package states', function () {
+    let args
+    beforeEach(function () {
+      args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts.json']
+    })
+
+    it('Group containing package to update and new package', function () {
       td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputRecommendGroups: ['package3', 'package4'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
       return emberNew()
         .then(() => modifyPackages([
           {name: 'my-package', version: '0.2.0', dev: true},        // installed
-          {name: 'ember-frost-core', version: '0.25.3', dev: true}, // installed
-          {name: 'ember-d3', version: '0.2.0', dev: true},          // installed
-          {name: 'ember-prop-types', version: '~0.2.0', dev: true}  // installed
+          {name: 'ember-frost-core', version: '0.25.2', dev: true}  // to update
         ]))
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
-          .to.have.eql(null))
+        .then(() => expect(packagesToInstall)
+          .to.have.lengthOf(3)
+          .to.contain('my-package@0.2.0')
+          .to.contain('ember-d3@0.2.0')
+          .to.contain('ember-frost-core@0.25.3'))
     })
 
-    describe('Non LTS', function () {
-      describe('Single package', function () {
-        beforeEach(function () {
-          td.when(prompt(td.matchers.anything())).thenResolve({
-            userInputInstallPkgs: ['ember-prop-types'],
-            confirmSelection: 'y'
-          })
-        })
-
-        it('New packages', function () {
-          return emberNew()
-            .then(() => emberGenerate(args))
-            .then(() => expect(packages)
-              .to.have.lengthOf(1)
-              .to.contain('ember-prop-types@~0.2.0'))
-        })
-
-        it('Packages to update', function () {
-          return emberNew()
-            .then(() => modifyPackages([
-              {name: 'ember-prop-types', version: '0.1.0', dev: true} // to update
-            ]))
-            .then(() => emberGenerate(args))
-            .then(() => expect(packages)
-              .to.have.lengthOf(1)
-              .to.contain('ember-prop-types@~0.2.0'))
-        })
+    it('Group containing package already installed and new package', function () {
+      td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputRecommendGroups: ['package3', 'package4'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
+        confirmSelection: 'y'
       })
+
+      return emberNew()
+        .then(() => modifyPackages([
+          {name: 'my-package', version: '0.2.0', dev: true},        // installed
+          {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
+        ]))
+        .then(() => emberGenerate(args))
+        .then(() => expect(packagesToInstall)
+          .to.have.lengthOf(3)
+          .to.contain('my-package@0.2.0')
+          .to.contain('ember-d3@0.2.0')
+          .to.contain('ember-frost-core@0.25.3'))
     })
 
-    describe('LTS', function () {
-      describe('Single package', function () {
-        it('New packages', function () {
-          td.when(prompt(td.matchers.anything())).thenResolve({
-            userInputInstallPkgs: ['ember-prop-types'],
-            confirmSelection: 'y'
-          })
-
-          return emberNew()
-            .then(() => emberGenerate(args))
-            .then(() => expect(packages)
-              .to.have.lengthOf(1)
-              .to.contain('ember-prop-types@~0.2.0'))
-        })
-
-        it('Packages to update', function () {
-          td.when(prompt(td.matchers.anything())).thenResolve({
-            // We need to mock this but those will be selected by default since we are on an LTS and
-            // that we already have those packages in our package.json
-            userInputInstallPkgs: ['ember-prop-types'],
-            confirmSelection: 'y'
-          })
-
-          return emberNew()
-            .then(() => modifyPackages([
-              {name: 'ember-prop-types', version: '0.1.0', dev: true} // to update
-            ]))
-            .then(() => emberGenerate(args))
-            .then(() => expect(packages)
-              .to.have.lengthOf(1)
-              .to.contain('ember-prop-types@~0.2.0'))
-        })
+    it('Group containing package already installed and package to update', function () {
+      td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputRecommendGroups: ['package3', 'package4'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
+        confirmSelection: 'y'
       })
+
+      return emberNew()
+        .then(() => modifyPackages([
+          {name: 'my-package', version: '0.2.0', dev: true},        // installed
+          {name: 'ember-frost-core', version: '0.25.2', dev: true}, // to update
+          {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
+        ]))
+        .then(() => emberGenerate(args))
+        .then(() => expect(packagesToInstall)
+          .to.have.lengthOf(3)
+          .to.contain('my-package@0.2.0')
+          .to.contain('ember-d3@0.2.0')
+          .to.contain('ember-frost-core@0.25.3'))
     })
   })
 
@@ -359,6 +510,8 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
     it('Already installed package', function () {
       td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputRecommendGroups: ['my-package-m'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
@@ -367,14 +520,16 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           {name: 'my-package-m', version: '0.2.0', dev: true}       // installed
         ]))
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
-          .to.be.eql(null))
+        .then(() => expect(packagesToInstall)
+          .to.have.lengthOf(1)
+          .to.contain('my-package-m@0.2.0'))
     })
 
     it('Package require update', function () {
       td.when(prompt(td.matchers.anything())).thenResolve({
         // We need to mock this but those will be selected by default since this package is mandatory
-        userInputInstallPkgs: ['my-package-m'],
+        userInputRecommendGroups: ['my-package-m'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
@@ -383,7 +538,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           {name: 'my-package-m', version: '0.1.0', dev: true}       // to update
         ]))
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
+        .then(() => expect(packagesToInstall)
           .to.have.lengthOf(1)
           .to.contain('my-package-m@0.2.0'))
     })
@@ -391,13 +546,14 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
     it('New package', function () {
       td.when(prompt(td.matchers.anything())).thenResolve({
         // We need to mock this but those will be selected by default since this package is mandatory
-        userInputInstallPkgs: ['my-package-m'],
+        userInputRecommendGroups: ['my-package-m'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
       return emberNew()
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
+        .then(() => expect(packagesToInstall)
           .to.have.lengthOf(1)
           .to.contain('my-package-m@0.2.0'))
     })
@@ -411,6 +567,8 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
     it('Already installed package', function () {
       td.when(prompt(td.matchers.anything())).thenResolve({
+        userInputRecommendGroups: ['my-package-m', 'my-package'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
@@ -420,14 +578,17 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           {name: 'my-package', version: '0.2.0', dev: true}         // installed
         ]))
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
-          .to.be.eql(null))
+        .then(() => expect(packagesToInstall)
+          .to.have.lengthOf(2)
+          .to.contain('my-package-m@0.2.0')
+          .to.contain('my-package@0.2.0'))
     })
 
     it('Package require update', function () {
       td.when(prompt(td.matchers.anything())).thenResolve({
         // We need to mock this but those will be selected by default since this package is mandatory (my-package-m)
-        userInputInstallPkgs: ['my-package-m', 'my-package'],
+        userInputRecommendGroups: ['my-package-m', 'my-package'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
@@ -437,7 +598,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           {name: 'my-package', version: '0.1.0', dev: true}         // to update
         ]))
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
+        .then(() => expect(packagesToInstall)
           .to.have.lengthOf(2)
           .to.contain('my-package-m@0.2.0')
           .to.contain('my-package@0.2.0'))
@@ -446,13 +607,14 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
     it('New package', function () {
       td.when(prompt(td.matchers.anything())).thenResolve({
         // We need to mock this but those will be selected by default since this package is mandatory (my-package-m)
-        userInputInstallPkgs: ['my-package-m', 'my-package'],
+        userInputRecommendGroups: ['my-package-m', 'my-package'],
+        userInputOtherGroups: otherPkgsToSelectByDefaylt,
         confirmSelection: 'y'
       })
 
       return emberNew()
         .then(() => emberGenerate(args))
-        .then(() => expect(packages)
+        .then(() => expect(packagesToInstall)
           .to.have.lengthOf(2)
           .to.contain('my-package-m@0.2.0')
           .to.contain('my-package@0.2.0'))

--- a/node-tests/blueprints/ember-frost-lts-test.js
+++ b/node-tests/blueprints/ember-frost-lts-test.js
@@ -181,7 +181,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
         return emberNew()
           .then(() => modifyPackages([
-            {name: 'ember-prop-types', version: '~3.0.0', dev: true} // installed
+            {name: 'ember-prop-types', version: '~3.0.0', dev: true}  // installed
           ]))
           .then(() => emberGenerate(args))
           .then(() => expect(packagesToInstall)
@@ -221,7 +221,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
         return emberNew()
           .then(() => modifyPackages([
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true}   // installed
+            {name: 'ember-cli-mocha', version: '0.2.0', dev: true}      // installed
           ]))
           .then(() => emberGenerate(args))
           .then(() => expect(packagesToInstall)
@@ -242,7 +242,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           .then(() => modifyPackages([
             {name: 'ember-d3', version: '0.2.0', dev: true},            // installed
             {name: 'ember-frost-core', version: '0.25.3', dev: true},   // installed
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true}     // installed
+            {name: 'ember-cli-mocha', version: '0.2.0', dev: true}      // installed
           ]))
           .then(() => emberGenerate(args))
           .then(() => expect(packagesToInstall)
@@ -283,9 +283,9 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
           return emberNew()
             .then(() => modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.1.0', dev: true},        // to update
-              {name: 'ember-frost-core', version: '0.25.2', dev: true}, // to update
-              {name: 'ember-d3', version: '0.1.0', dev: true}           // to update
+              {name: 'ember-cli-mocha', version: '0.1.0', dev: true},         // to update
+              {name: 'ember-frost-core', version: '0.25.2', dev: true},       // to update
+              {name: 'ember-d3', version: '0.1.0', dev: true}                 // to update
             ]))
             .then(() => emberGenerate(args))
             .then(() => expect(packagesToInstall)
@@ -304,9 +304,9 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
           return emberNew()
             .then(() => modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.2.0', dev: true},        // installed
-              {name: 'ember-frost-core', version: '0.25.3', dev: true}, // installed
-              {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
+              {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
+              {name: 'ember-frost-core', version: '0.25.3', dev: true},       // installed
+              {name: 'ember-d3', version: '0.2.0', dev: true}                 // installed
             ]))
             .then(() => emberGenerate(args))
             .then(() => expect(packagesToInstall)
@@ -338,9 +338,9 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
           return emberNew()
             .then(() => modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.1.0', dev: true},        // to update
-              {name: 'ember-frost-core', version: '0.25.2', dev: true}, // to update
-              {name: 'ember-d3', version: '0.1.0', dev: true}           // to update
+              {name: 'ember-cli-mocha', version: '0.1.0', dev: true},         // to update
+              {name: 'ember-frost-core', version: '0.25.2', dev: true},       // to update
+              {name: 'ember-d3', version: '0.1.0', dev: true}                 // to update
             ]))
             .then(() => emberGenerate(args))
             .then(() => expect(packagesToInstall)
@@ -355,9 +355,9 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
           return emberNew()
             .then(() => modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.2.0', dev: true},        // installed
-              {name: 'ember-frost-core', version: '0.25.3', dev: true}, // installed
-              {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
+              {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
+              {name: 'ember-frost-core', version: '0.25.3', dev: true},       // installed
+              {name: 'ember-d3', version: '0.2.0', dev: true}                 // installed
             ]))
             .then(() => emberGenerate(args))
             .then(() => expect(packagesToInstall)
@@ -421,8 +421,8 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
         return emberNew()
           .then(() => modifyPackages([
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true},        // installed
-            {name: 'ember-frost-core', version: '0.25.2', dev: true}  // to update
+            {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
+            {name: 'ember-frost-core', version: '0.25.2', dev: true}        // to update
           ]))
           .then(() => emberGenerate(args))
           .then(() => expect(packagesToInstall)
@@ -441,8 +441,8 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
         return emberNew()
           .then(() => modifyPackages([
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true},        // installed
-            {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
+            {name: 'ember-cli-mocha', version: '0.2.0', dev: true},       // installed
+            {name: 'ember-d3', version: '0.2.0', dev: true}               // installed
           ]))
           .then(() => emberGenerate(args))
           .then(() => expect(packagesToInstall)
@@ -461,9 +461,9 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
         return emberNew()
           .then(() => modifyPackages([
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true},        // installed
-            {name: 'ember-frost-core', version: '0.25.2', dev: true}, // to update
-            {name: 'ember-d3', version: '0.2.0', dev: true}           // installed
+            {name: 'ember-cli-mocha', version: '0.2.0', dev: true},       // installed
+            {name: 'ember-frost-core', version: '0.25.2', dev: true},     // to update
+            {name: 'ember-d3', version: '0.2.0', dev: true}               // installed
           ]))
           .then(() => emberGenerate(args))
           .then(() => expect(packagesToInstall)
@@ -547,8 +547,8 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
       return emberNew()
         .then(() => modifyPackages([
-          {name: 'ember-cli-chai', version: '0.0.10', dev: true},      // installed
-          {name: 'ember-cli-mocha', version: '0.2.0', dev: true}         // installed
+          {name: 'ember-cli-chai', version: '0.0.10', dev: true},         // installed
+          {name: 'ember-cli-mocha', version: '0.2.0', dev: true}          // installed
         ]))
         .then(() => emberGenerate(args))
         .then(() => expect(packagesToInstall)
@@ -567,8 +567,8 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
       return emberNew()
         .then(() => modifyPackages([
-          {name: 'ember-cli-chai', version: '0.0.9', dev: true},      // to update
-          {name: 'ember-cli-mocha', version: '0.1.0', dev: true}         // to update
+          {name: 'ember-cli-chai', version: '0.0.9', dev: true},          // to update
+          {name: 'ember-cli-mocha', version: '0.1.0', dev: true}          // to update
         ]))
         .then(() => emberGenerate(args))
         .then(() => expect(packagesToInstall)

--- a/node-tests/blueprints/ember-frost-lts-test.js
+++ b/node-tests/blueprints/ember-frost-lts-test.js
@@ -20,7 +20,6 @@ const td = require('testdouble')
 const requireFromCLI = require('ember-cli-blueprint-test-helpers/lib/helpers/require-from-cli')
 const Blueprint = requireFromCLI('lib/models/blueprint')
 const MockUI = requireFromCLI('tests/helpers/mock-ui')
-const MockNpm = require('../../lib/utils/npm')
 
 const otherPkgsToSelectByDefaylt = [
   'broccoli-asset-rev',

--- a/node-tests/blueprints/ember-frost-lts-test.js
+++ b/node-tests/blueprints/ember-frost-lts-test.js
@@ -141,20 +141,6 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           .to.contain('my-package@0.2.0'))
     })
 
-    it('User request only 1 package', function () {
-      td.when(prompt(td.matchers.anything())).thenResolve({
-        userInputRecommendGroups: ['ember-prop-types'],
-        userInputOtherGroups: otherPkgsToSelectByDefaylt,
-        confirmSelection: 'y'
-      })
-
-      return emberNew()
-        .then(() => emberGenerate(args))
-        .then(() => expect(packagesToInstall)
-          .to.have.lengthOf(1)
-          .to.contain('ember-prop-types@~0.2.0'))
-    })
-
     it('User request everything', function () {
       td.when(prompt(td.matchers.anything())).thenResolve({
         userInputRecommendGroups: ['package3', 'package4', 'ember-prop-types'],

--- a/node-tests/blueprints/ember-frost-lts-test.js
+++ b/node-tests/blueprints/ember-frost-lts-test.js
@@ -1,27 +1,27 @@
 'use strict'
 
-const blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers')
-const setupTestHooks = blueprintHelpers.setupTestHooks
-const emberNew = blueprintHelpers.emberNew
-const emberGenerate = blueprintHelpers.emberGenerate
-const modifyPackages = blueprintHelpers.modifyPackages
+var blueprintHelpers = require('ember-cli-blueprint-test-helpers/helpers')
+var setupTestHooks = blueprintHelpers.setupTestHooks
+var emberNew = blueprintHelpers.emberNew
+var emberGenerate = blueprintHelpers.emberGenerate
+var modifyPackages = blueprintHelpers.modifyPackages
 
-const chai = require('ember-cli-blueprint-test-helpers/chai')
-const expect = chai.expect
+var chai = require('ember-cli-blueprint-test-helpers/chai')
+var expect = chai.expect
 
-const mocha = require('mocha')
-const it = mocha.it
-const describe = mocha.describe
-const beforeEach = mocha.beforeEach
-const afterEach = mocha.afterEach
+var mocha = require('mocha')
+var it = mocha.it
+var describe = mocha.describe
+var beforeEach = mocha.beforeEach
+var afterEach = mocha.afterEach
 
-const td = require('testdouble')
+var td = require('testdouble')
 
-const requireFromCLI = require('ember-cli-blueprint-test-helpers/lib/helpers/require-from-cli')
-const Blueprint = requireFromCLI('lib/models/blueprint')
-const MockUI = requireFromCLI('tests/helpers/mock-ui')
+var requireFromCLI = require('ember-cli-blueprint-test-helpers/lib/helpers/require-from-cli')
+var Blueprint = requireFromCLI('lib/models/blueprint')
+var MockUI = requireFromCLI('tests/helpers/mock-ui')
 
-const otherPkgsToSelectByDefaylt = [
+var otherPkgsToSelectByDefaylt = [
   'broccoli-asset-rev',
   'ember-ajax',
   'ember-cli',
@@ -49,22 +49,22 @@ const otherPkgsToSelectByDefaylt = [
 describe('Acceptance: ember generate ember-frost-lts', function () {
   setupTestHooks(this)
 
-  let prompt, packagesToInstall, packagesToUninstall
+  var prompt, packagesToInstall, packagesToUninstall
   beforeEach(function () {
     // Mock the UI prompt to avoid prompting during tests
     prompt = td.function()
     td.replace(MockUI.prototype, 'prompt', prompt)
 
     // Mock the behavior on install to get the packages installed
-    const installTaskRun = td.function()
-    td.when(installTaskRun(td.matchers.anything())).thenDo((task) => { packagesToInstall = task.packages })
+    var installTaskRun = td.function()
+    td.when(installTaskRun(td.matchers.anything())).thenDo(function (task) { packagesToInstall = task.packages })
 
     // Mock the behavior on uninstall to get the packages uninstall
-    const uninstallTaskRun = td.function()
-    td.when(uninstallTaskRun(td.matchers.anything())).thenDo((task) => { packagesToUninstall = task.packages })
+    var uninstallTaskRun = td.function()
+    td.when(uninstallTaskRun(td.matchers.anything())).thenDo(function (task) { packagesToUninstall = task.packages })
 
     // Mock the behavior on addon-install
-    const taskFor = td.function()
+    var taskFor = td.function()
     td.when(taskFor('addon-install')).thenReturn({ run: installTaskRun })
     td.when(taskFor('npm-uninstall')).thenReturn({ run: uninstallTaskRun })
 
@@ -79,20 +79,22 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
   })
 
   it('No package to install (empty file)', function () {
-    const args = ['ember-frost-lts', '--lts-file=node-tests/mock/empty-lts.json']
+    var args = ['ember-frost-lts', '--lts-file=node-tests/mock/empty-lts.json']
     td.when(prompt(td.matchers.anything())).thenResolve({
       userInputOtherGroups: otherPkgsToSelectByDefaylt,
       confirmSelection: 'y'
     })
 
     return emberNew()
-      .then(() => emberGenerate(args))
-      .then(() => expect(packagesToInstall)
-        .to.be.eql(null))
+      .then(function () { emberGenerate(args) })
+      .then(function () {
+        expect(packagesToInstall)
+          .to.be.eql(null)
+      })
   })
 
   it('Single package', function () {
-    const args = ['ember-frost-lts', '--lts-file=node-tests/mock/single-package-lts.json']
+    var args = ['ember-frost-lts', '--lts-file=node-tests/mock/single-package-lts.json']
     td.when(prompt(td.matchers.anything())).thenResolve({
       userInputRecommendGroups: ['ember-prop-types'],
       userInputOtherGroups: otherPkgsToSelectByDefaylt,
@@ -100,14 +102,16 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
     })
 
     return emberNew()
-      .then(() => emberGenerate(args))
-      .then(() => expect(packagesToInstall)
-        .to.have.lengthOf(1)
-        .to.contain('ember-prop-types@~3.0.0'))
+      .then(function () { return emberGenerate(args) })
+      .then(function () {
+        expect(packagesToInstall)
+          .to.have.lengthOf(1)
+          .to.contain('ember-prop-types@~3.0.0')
+      })
   })
 
   it('Single group', function () {
-    const args = ['ember-frost-lts', '--lts-file=node-tests/mock/single-group-lts.json']
+    var args = ['ember-frost-lts', '--lts-file=node-tests/mock/single-group-lts.json']
     td.when(prompt(td.matchers.anything())).thenResolve({
       userInputRecommendGroups: ['package3'],
       userInputOtherGroups: otherPkgsToSelectByDefaylt,
@@ -115,14 +119,16 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
     })
 
     return emberNew()
-      .then(() => emberGenerate(args))
-      .then(() => expect(packagesToInstall)
-        .to.have.lengthOf(1)
-        .to.contain('ember-cli-mocha@0.2.0'))
+      .then(function () { return emberGenerate(args) })
+      .then(function () {
+        expect(packagesToInstall)
+          .to.have.lengthOf(1)
+          .to.contain('ember-cli-mocha@0.2.0')
+      })
   })
 
   describe('Package and group', function () {
-    let args
+    var args
     beforeEach(function () {
       args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts.json']
     })
@@ -136,10 +142,12 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.have.lengthOf(1)
-            .to.contain('ember-cli-mocha@0.2.0'))
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.have.lengthOf(1)
+              .to.contain('ember-cli-mocha@0.2.0')
+          })
       })
 
       it('User request everything', function () {
@@ -150,13 +158,15 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.have.lengthOf(4)
-            .to.contain('ember-cli-mocha@0.2.0')
-            .to.contain('ember-prop-types@~3.0.0')
-            .to.contain('ember-frost-core@0.25.3')
-            .to.contain('ember-d3@0.2.0'))
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.have.lengthOf(4)
+              .to.contain('ember-cli-mocha@0.2.0')
+              .to.contain('ember-prop-types@~3.0.0')
+              .to.contain('ember-frost-core@0.25.3')
+              .to.contain('ember-d3@0.2.0')
+          })
       })
 
       it('User request install recommended package', function () {
@@ -167,10 +177,12 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.have.lengthOf(1)
-            .to.contain('ember-prop-types@~3.0.0'))
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.have.lengthOf(1)
+              .to.contain('ember-prop-types@~3.0.0')
+          })
       })
 
       it('User request uninstall recommended package', function () {
@@ -180,15 +192,21 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => modifyPackages([
-            {name: 'ember-prop-types', version: '~3.0.0', dev: true}  // installed
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.be.eql(null))
-          .then(() => expect(packagesToUninstall)
-            .to.have.lengthOf(1)
-            .to.contain('ember-prop-types'))
+          .then(function () {
+            modifyPackages([
+              {name: 'ember-prop-types', version: '~3.0.0', dev: true}  // installed
+            ])
+          })
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.be.eql(null)
+          })
+          .then(function () {
+            expect(packagesToUninstall)
+              .to.have.lengthOf(1)
+              .to.contain('ember-prop-types')
+          })
       })
 
       it('User request install + uninstall recommended package', function () {
@@ -199,18 +217,24 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => modifyPackages([
-            {name: 'ember-d3', version: '0.2.0', dev: true},          // installed
-            {name: 'ember-frost-core', version: '0.25.3', dev: true}  // installed
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.have.lengthOf(1)
-            .to.contain('ember-prop-types@~3.0.0'))
-          .then(() => expect(packagesToUninstall)
-            .to.have.lengthOf(2)
-            .to.contain('ember-d3')
-            .to.contain('ember-frost-core'))
+          .then(function () {
+            modifyPackages([
+              {name: 'ember-d3', version: '0.2.0', dev: true},          // installed
+              {name: 'ember-frost-core', version: '0.25.3', dev: true}  // installed
+            ])
+          })
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.have.lengthOf(1)
+              .to.contain('ember-prop-types@~3.0.0')
+          })
+          .then(function () {
+            expect(packagesToUninstall)
+              .to.have.lengthOf(2)
+              .to.contain('ember-d3')
+              .to.contain('ember-frost-core')
+          })
       })
 
       it('User request uninstall other package', function () {
@@ -220,15 +244,21 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => modifyPackages([
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true}      // installed
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.be.eql(null))
-          .then(() => expect(packagesToUninstall)
-            .to.have.lengthOf(1)
-            .to.contain('ember-cli-mocha'))
+          .then(function () {
+            modifyPackages([
+              {name: 'ember-cli-mocha', version: '0.2.0', dev: true}      // installed
+            ])
+          })
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.be.eql(null)
+          })
+          .then(function () {
+            expect(packagesToUninstall)
+              .to.have.lengthOf(1)
+              .to.contain('ember-cli-mocha')
+          })
       })
 
       it('User request install + uninstall recommended package and unistall other package', function () {
@@ -239,20 +269,26 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => modifyPackages([
-            {name: 'ember-d3', version: '0.2.0', dev: true},            // installed
-            {name: 'ember-frost-core', version: '0.25.3', dev: true},   // installed
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true}      // installed
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.have.lengthOf(1)
-            .to.contain('ember-prop-types@~3.0.0'))
-          .then(() => expect(packagesToUninstall)
-            .to.have.lengthOf(3)
-            .to.contain('ember-d3')
-            .to.contain('ember-frost-core')
-            .to.contain('ember-cli-mocha'))
+          .then(function () {
+            modifyPackages([
+              {name: 'ember-d3', version: '0.2.0', dev: true},            // installed
+              {name: 'ember-frost-core', version: '0.25.3', dev: true},   // installed
+              {name: 'ember-cli-mocha', version: '0.2.0', dev: true}      // installed
+            ])
+          })
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.have.lengthOf(1)
+              .to.contain('ember-prop-types@~3.0.0')
+          })
+          .then(function () {
+            expect(packagesToUninstall)
+              .to.have.lengthOf(3)
+              .to.contain('ember-d3')
+              .to.contain('ember-frost-core')
+              .to.contain('ember-cli-mocha')
+          })
       })
     })
 
@@ -266,12 +302,14 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           })
 
           return emberNew()
-            .then(() => emberGenerate(args))
-            .then(() => expect(packagesToInstall)
-              .to.have.lengthOf(3)
-              .to.contain('ember-cli-mocha@0.2.0')
-              .to.contain('ember-d3@0.2.0')
-              .to.contain('ember-frost-core@0.25.3'))
+            .then(function () { return emberGenerate(args) })
+            .then(function () {
+              expect(packagesToInstall)
+                .to.have.lengthOf(3)
+                .to.contain('ember-cli-mocha@0.2.0')
+                .to.contain('ember-d3@0.2.0')
+                .to.contain('ember-frost-core@0.25.3')
+            })
         })
 
         it('Group containing only packages to update', function () {
@@ -282,17 +320,21 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           })
 
           return emberNew()
-            .then(() => modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.1.0', dev: true},         // to update
-              {name: 'ember-frost-core', version: '0.25.2', dev: true},       // to update
-              {name: 'ember-d3', version: '0.1.0', dev: true}                 // to update
-            ]))
-            .then(() => emberGenerate(args))
-            .then(() => expect(packagesToInstall)
-              .to.have.lengthOf(3)
-              .to.contain('ember-cli-mocha@0.2.0')
-              .to.contain('ember-d3@0.2.0')
-              .to.contain('ember-frost-core@0.25.3'))
+            .then(function () {
+              modifyPackages([
+                {name: 'ember-cli-mocha', version: '0.1.0', dev: true},         // to update
+                {name: 'ember-frost-core', version: '0.25.2', dev: true},       // to update
+                {name: 'ember-d3', version: '0.1.0', dev: true}                 // to update
+              ])
+            })
+            .then(function () { return emberGenerate(args) })
+            .then(function () {
+              expect(packagesToInstall)
+                .to.have.lengthOf(3)
+                .to.contain('ember-cli-mocha@0.2.0')
+                .to.contain('ember-d3@0.2.0')
+                .to.contain('ember-frost-core@0.25.3')
+            })
         })
 
         it('Group containing packages already installed', function () {
@@ -303,17 +345,21 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           })
 
           return emberNew()
-            .then(() => modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
-              {name: 'ember-frost-core', version: '0.25.3', dev: true},       // installed
-              {name: 'ember-d3', version: '0.2.0', dev: true}                 // installed
-            ]))
-            .then(() => emberGenerate(args))
-            .then(() => expect(packagesToInstall)
-              .to.have.lengthOf(3)
-              .to.contain('ember-cli-mocha@0.2.0')
-              .to.contain('ember-d3@0.2.0')
-              .to.contain('ember-frost-core@0.25.3'))
+            .then(function () {
+              modifyPackages([
+                {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
+                {name: 'ember-frost-core', version: '0.25.3', dev: true},       // installed
+                {name: 'ember-d3', version: '0.2.0', dev: true}                 // installed
+              ])
+            })
+            .then(function () { return emberGenerate(args) })
+            .then(function () {
+              expect(packagesToInstall)
+                .to.have.lengthOf(3)
+                .to.contain('ember-cli-mocha@0.2.0')
+                .to.contain('ember-d3@0.2.0')
+                .to.contain('ember-frost-core@0.25.3')
+            })
         })
       })
 
@@ -325,9 +371,11 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           })
 
           return emberNew()
-            .then(() => emberGenerate(args))
-            .then(() => expect(packagesToInstall)
-              .to.be.eql(null))
+            .then(function () { return emberGenerate(args) })
+            .then(function () {
+              expect(packagesToInstall)
+                .to.be.eql(null)
+            })
         })
 
         it('Group containing only packages to update', function () {
@@ -337,14 +385,18 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           })
 
           return emberNew()
-            .then(() => modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.1.0', dev: true},         // to update
-              {name: 'ember-frost-core', version: '0.25.2', dev: true},       // to update
-              {name: 'ember-d3', version: '0.1.0', dev: true}                 // to update
-            ]))
-            .then(() => emberGenerate(args))
-            .then(() => expect(packagesToInstall)
-              .to.be.eql(null))
+            .then(function () {
+              modifyPackages([
+                {name: 'ember-cli-mocha', version: '0.1.0', dev: true},         // to update
+                {name: 'ember-frost-core', version: '0.25.2', dev: true},       // to update
+                {name: 'ember-d3', version: '0.1.0', dev: true}                 // to update
+              ])
+            })
+            .then(function () { return emberGenerate(args) })
+            .then(function () {
+              expect(packagesToInstall)
+                .to.be.eql(null)
+            })
         })
 
         it('Group containing packages already installed', function () {
@@ -354,19 +406,25 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           })
 
           return emberNew()
-            .then(() => modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
-              {name: 'ember-frost-core', version: '0.25.3', dev: true},       // installed
-              {name: 'ember-d3', version: '0.2.0', dev: true}                 // installed
-            ]))
-            .then(() => emberGenerate(args))
-            .then(() => expect(packagesToInstall)
-              .to.be.eql(null))
-            .then(() => expect(packagesToUninstall)
-              .to.have.lengthOf(3)
-              .to.contain('ember-cli-mocha')
-              .to.contain('ember-d3')
-              .to.contain('ember-frost-core'))
+            .then(function () {
+              modifyPackages([
+                {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
+                {name: 'ember-frost-core', version: '0.25.3', dev: true},       // installed
+                {name: 'ember-d3', version: '0.2.0', dev: true}                 // installed
+              ])
+            })
+            .then(function () { return emberGenerate(args) })
+            .then(function () {
+              expect(packagesToInstall)
+                .to.be.eql(null)
+            })
+            .then(function () {
+              expect(packagesToUninstall)
+                .to.have.lengthOf(3)
+                .to.contain('ember-cli-mocha')
+                .to.contain('ember-d3')
+                .to.contain('ember-frost-core')
+            })
         })
       })
     })
@@ -374,21 +432,23 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
     describe('Other packages - Action based on selection', function () {
       describe('Selected', function () {
         it('Group containing packages already installed', function () {
-          console.log('before', otherPkgsToSelectByDefaylt)
-          const otherPkgsSelected = otherPkgsToSelectByDefaylt.concat(['ember-cli-mocha2'])
-          console.log('after', otherPkgsSelected)
+          var otherPkgsSelected = otherPkgsToSelectByDefaylt.concat(['ember-cli-mocha2'])
           td.when(prompt(td.matchers.anything())).thenResolve({
             userInputOtherGroups: otherPkgsSelected,
             confirmSelection: 'y'
           })
 
           return emberNew()
-            .then(() => modifyPackages([
-              {name: 'ember-cli-mocha2', version: '0.2.0', dev: true}        // installed
-            ]))
-            .then(() => emberGenerate(args))
-            .then(() => expect(packagesToUninstall)
-              .to.be.eql(null))
+            .then(function () {
+              modifyPackages([
+                {name: 'ember-cli-mocha2', version: '0.2.0', dev: true}        // installed
+              ])
+            })
+            .then(function () { return emberGenerate(args) })
+            .then(function () {
+              expect(packagesToUninstall)
+                .to.be.eql(null)
+            })
         })
       })
 
@@ -400,13 +460,17 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
           })
 
           return emberNew()
-            .then(() => modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.2.0', dev: true}        // installed
-            ]))
-            .then(() => emberGenerate(args))
-            .then(() => expect(packagesToUninstall)
-              .to.have.lengthOf(1)
-              .to.contain('ember-cli-mocha'))
+            .then(function () {
+              modifyPackages([
+                {name: 'ember-cli-mocha', version: '0.2.0', dev: true}        // installed
+              ])
+            })
+            .then(function () { return emberGenerate(args) })
+            .then(function () {
+              expect(packagesToUninstall)
+                .to.have.lengthOf(1)
+                .to.contain('ember-cli-mocha')
+            })
         })
       })
     })
@@ -420,16 +484,20 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => modifyPackages([
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
-            {name: 'ember-frost-core', version: '0.25.2', dev: true}        // to update
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.have.lengthOf(3)
-            .to.contain('ember-cli-mocha@0.2.0')
-            .to.contain('ember-d3@0.2.0')
-            .to.contain('ember-frost-core@0.25.3'))
+          .then(function () {
+            modifyPackages([
+              {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
+              {name: 'ember-frost-core', version: '0.25.2', dev: true}        // to update
+            ])
+          })
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.have.lengthOf(3)
+              .to.contain('ember-cli-mocha@0.2.0')
+              .to.contain('ember-d3@0.2.0')
+              .to.contain('ember-frost-core@0.25.3')
+          })
       })
 
       it('Group containing package already installed and new package', function () {
@@ -440,16 +508,20 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => modifyPackages([
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true},       // installed
-            {name: 'ember-d3', version: '0.2.0', dev: true}               // installed
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.have.lengthOf(3)
-            .to.contain('ember-cli-mocha@0.2.0')
-            .to.contain('ember-d3@0.2.0')
-            .to.contain('ember-frost-core@0.25.3'))
+          .then(function () {
+            modifyPackages([
+              {name: 'ember-cli-mocha', version: '0.2.0', dev: true},       // installed
+              {name: 'ember-d3', version: '0.2.0', dev: true}               // installed
+            ])
+          })
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.have.lengthOf(3)
+              .to.contain('ember-cli-mocha@0.2.0')
+              .to.contain('ember-d3@0.2.0')
+              .to.contain('ember-frost-core@0.25.3')
+          })
       })
 
       it('Group containing package already installed and package to update', function () {
@@ -460,23 +532,27 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
         })
 
         return emberNew()
-          .then(() => modifyPackages([
-            {name: 'ember-cli-mocha', version: '0.2.0', dev: true},       // installed
-            {name: 'ember-frost-core', version: '0.25.2', dev: true},     // to update
-            {name: 'ember-d3', version: '0.2.0', dev: true}               // installed
-          ]))
-          .then(() => emberGenerate(args))
-          .then(() => expect(packagesToInstall)
-            .to.have.lengthOf(3)
-            .to.contain('ember-cli-mocha@0.2.0')
-            .to.contain('ember-d3@0.2.0')
-            .to.contain('ember-frost-core@0.25.3'))
+          .then(function () {
+            modifyPackages([
+              {name: 'ember-cli-mocha', version: '0.2.0', dev: true},       // installed
+              {name: 'ember-frost-core', version: '0.25.2', dev: true},     // to update
+              {name: 'ember-d3', version: '0.2.0', dev: true}               // installed
+            ])
+          })
+          .then(function () { return emberGenerate(args) })
+          .then(function () {
+            expect(packagesToInstall)
+              .to.have.lengthOf(3)
+              .to.contain('ember-cli-mocha@0.2.0')
+              .to.contain('ember-d3@0.2.0')
+              .to.contain('ember-frost-core@0.25.3')
+          })
       })
     })
   })
 
   describe('Mandatory', function () {
-    let args
+    var args
     beforeEach(function () {
       args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts-mandatory.json']
     })
@@ -489,13 +565,17 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
       })
 
       return emberNew()
-        .then(() => modifyPackages([
-          {name: 'ember-cli-chai', version: '0.0.10', dev: true}       // installed
-        ]))
-        .then(() => emberGenerate(args))
-        .then(() => expect(packagesToInstall)
-          .to.have.lengthOf(1)
-          .to.contain('ember-cli-chai@0.0.10'))
+        .then(function () {
+          modifyPackages([
+            {name: 'ember-cli-chai', version: '0.0.10', dev: true}       // installed
+          ])
+        })
+        .then(function () { return emberGenerate(args) })
+        .then(function () {
+          expect(packagesToInstall)
+            .to.have.lengthOf(1)
+            .to.contain('ember-cli-chai@0.0.10')
+        })
     })
 
     it('Package require update', function () {
@@ -507,13 +587,17 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
       })
 
       return emberNew()
-        .then(() => modifyPackages([
-          {name: 'ember-cli-chai', version: '0.1.0', dev: true}       // to update
-        ]))
-        .then(() => emberGenerate(args))
-        .then(() => expect(packagesToInstall)
-          .to.have.lengthOf(1)
-          .to.contain('ember-cli-chai@0.0.10'))
+        .then(function () {
+          modifyPackages([
+            {name: 'ember-cli-chai', version: '0.1.0', dev: true}       // to update
+          ])
+        })
+        .then(function () { return emberGenerate(args) })
+        .then(function () {
+          expect(packagesToInstall)
+            .to.have.lengthOf(1)
+            .to.contain('ember-cli-chai@0.0.10')
+        })
     })
 
     it('New package', function () {
@@ -525,15 +609,17 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
       })
 
       return emberNew()
-        .then(() => emberGenerate(args))
-        .then(() => expect(packagesToInstall)
-          .to.have.lengthOf(1)
-          .to.contain('ember-cli-chai@0.0.10'))
+        .then(function () { return emberGenerate(args) })
+        .then(function () {
+          expect(packagesToInstall)
+            .to.have.lengthOf(1)
+            .to.contain('ember-cli-chai@0.0.10')
+        })
     })
   })
 
   describe('Mandatory + Optional', function () {
-    let args
+    var args
     beforeEach(function () {
       args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts-mandatory-optional.json']
     })
@@ -546,15 +632,19 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
       })
 
       return emberNew()
-        .then(() => modifyPackages([
-          {name: 'ember-cli-chai', version: '0.0.10', dev: true},         // installed
-          {name: 'ember-cli-mocha', version: '0.2.0', dev: true}          // installed
-        ]))
-        .then(() => emberGenerate(args))
-        .then(() => expect(packagesToInstall)
-          .to.have.lengthOf(2)
-          .to.contain('ember-cli-chai@0.0.10')
-          .to.contain('ember-cli-mocha@0.2.0'))
+        .then(function () {
+          modifyPackages([
+            {name: 'ember-cli-chai', version: '0.0.10', dev: true},         // installed
+            {name: 'ember-cli-mocha', version: '0.2.0', dev: true}          // installed
+          ])
+        })
+        .then(function () { return emberGenerate(args) })
+        .then(function () {
+          expect(packagesToInstall)
+            .to.have.lengthOf(2)
+            .to.contain('ember-cli-chai@0.0.10')
+            .to.contain('ember-cli-mocha@0.2.0')
+        })
     })
 
     it('Package require update', function () {
@@ -566,15 +656,19 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
       })
 
       return emberNew()
-        .then(() => modifyPackages([
-          {name: 'ember-cli-chai', version: '0.0.9', dev: true},          // to update
-          {name: 'ember-cli-mocha', version: '0.1.0', dev: true}          // to update
-        ]))
-        .then(() => emberGenerate(args))
-        .then(() => expect(packagesToInstall)
-          .to.have.lengthOf(2)
-          .to.contain('ember-cli-chai@0.0.10')
-          .to.contain('ember-cli-mocha@0.2.0'))
+        .then(function () {
+          modifyPackages([
+            {name: 'ember-cli-chai', version: '0.0.9', dev: true},          // to update
+            {name: 'ember-cli-mocha', version: '0.1.0', dev: true}          // to update
+          ])
+        })
+        .then(function () { return emberGenerate(args) })
+        .then(function () {
+          expect(packagesToInstall)
+            .to.have.lengthOf(2)
+            .to.contain('ember-cli-chai@0.0.10')
+            .to.contain('ember-cli-mocha@0.2.0')
+        })
     })
 
     it('New package', function () {
@@ -586,11 +680,13 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
       })
 
       return emberNew()
-        .then(() => emberGenerate(args))
-        .then(() => expect(packagesToInstall)
-          .to.have.lengthOf(2)
-          .to.contain('ember-cli-chai@0.0.10')
-          .to.contain('ember-cli-mocha@0.2.0'))
+        .then(function () { return emberGenerate(args) })
+        .then(function () {
+          expect(packagesToInstall)
+            .to.have.lengthOf(2)
+            .to.contain('ember-cli-chai@0.0.10')
+            .to.contain('ember-cli-mocha@0.2.0')
+        })
     })
   })
 })

--- a/node-tests/blueprints/ember-frost-lts-test.js
+++ b/node-tests/blueprints/ember-frost-lts-test.js
@@ -46,6 +46,15 @@ var otherPkgsToSelectByDefaylt = [
   'ember-frost-lts'
 ]
 
+var installedPkgsMochaCoreD3 = [
+  {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
+  {name: 'ember-frost-core', version: '0.25.3', dev: true},       // installed
+  {name: 'ember-d3', version: '0.2.0', dev: true}                 // installed
+]
+var installedPkgsChai = [
+  {name: 'ember-cli-mocha', version: '0.2.0', dev: true}        // installed
+]
+
 describe('Acceptance: ember generate ember-frost-lts', function () {
   setupTestHooks(this)
 
@@ -245,9 +254,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
         return emberNew()
           .then(function () {
-            modifyPackages([
-              {name: 'ember-cli-mocha', version: '0.2.0', dev: true}      // installed
-            ])
+            modifyPackages(installedPkgsChai)
           })
           .then(function () { return emberGenerate(args) })
           .then(function () {
@@ -346,11 +353,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
           return emberNew()
             .then(function () {
-              modifyPackages([
-                {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
-                {name: 'ember-frost-core', version: '0.25.3', dev: true},       // installed
-                {name: 'ember-d3', version: '0.2.0', dev: true}                 // installed
-              ])
+              modifyPackages(installedPkgsMochaCoreD3)
             })
             .then(function () { return emberGenerate(args) })
             .then(function () {
@@ -388,7 +391,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
             .then(function () {
               modifyPackages([
                 {name: 'ember-cli-mocha', version: '0.1.0', dev: true},         // to update
-                {name: 'ember-frost-core', version: '0.25.2', dev: true},       // to update
+                {name: 'ember-frost-core', version: '0.25.1', dev: true},       // to update
                 {name: 'ember-d3', version: '0.1.0', dev: true}                 // to update
               ])
             })
@@ -407,11 +410,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
           return emberNew()
             .then(function () {
-              modifyPackages([
-                {name: 'ember-cli-mocha', version: '0.2.0', dev: true},         // installed
-                {name: 'ember-frost-core', version: '0.25.3', dev: true},       // installed
-                {name: 'ember-d3', version: '0.2.0', dev: true}                 // installed
-              ])
+              modifyPackages(installedPkgsMochaCoreD3)
             })
             .then(function () { return emberGenerate(args) })
             .then(function () {
@@ -461,9 +460,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
 
           return emberNew()
             .then(function () {
-              modifyPackages([
-                {name: 'ember-cli-mocha', version: '0.2.0', dev: true}        // installed
-              ])
+              modifyPackages(installedPkgsChai)
             })
             .then(function () { return emberGenerate(args) })
             .then(function () {

--- a/node-tests/mock/package-group-lts-mandatory-optional.json
+++ b/node-tests/mock/package-group-lts-mandatory-optional.json
@@ -1,6 +1,6 @@
 {
   "mandatory": {
-    "my-package-m": "0.2.0"
+    "ember-cli-chai": "0.0.10"
   },
-  "my-package": "0.2.0"
+  "ember-cli-mocha": "0.2.0"
 }

--- a/node-tests/mock/package-group-lts-mandatory.json
+++ b/node-tests/mock/package-group-lts-mandatory.json
@@ -1,5 +1,5 @@
 {
   "mandatory": {
-    "my-package-m": "0.2.0"
+    "ember-cli-chai": "0.0.10"
   }
 }

--- a/node-tests/mock/package-group-lts.json
+++ b/node-tests/mock/package-group-lts.json
@@ -1,7 +1,7 @@
 {
   "package3": {
     "packages": {
-      "my-package": "0.2.0"
+      "ember-cli-mocha": "0.2.0"
     }
   },
   "package4": {
@@ -10,5 +10,5 @@
       "ember-d3": "0.2.0"
     }
   },
-  "ember-prop-types": "~0.2.0"
+  "ember-prop-types": "~3.0.0"
 }

--- a/node-tests/mock/single-group-lts.json
+++ b/node-tests/mock/single-group-lts.json
@@ -1,7 +1,7 @@
 {
   "package3": {
     "packages": {
-      "my-package": "0.2.0"
+      "ember-cli-mocha": "0.2.0"
     }
   }
 }

--- a/node-tests/mock/single-package-lts.json
+++ b/node-tests/mock/single-package-lts.json
@@ -1,3 +1,3 @@
 {
-  "ember-prop-types": "~0.2.0"
+  "ember-prop-types": "~3.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -53,13 +53,13 @@
   ],
   "dependencies": {
     "child-process-promise": "^2.1.3",
+    "cli-spinner": "^0.2.5",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",
     "ember-computed-decorators": ">=0.2.2 <2.0.0",
-    "promise": "^7.1.1",
-    "cli-spinner": "^0.2.5",
-    "lodash": "^4.15.0"
+    "lodash": "^4.15.0",
+    "promise": "^7.1.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "cli-spinner": "^0.2.5",
     "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-blueprint-test-helpers": "^0.13.0",
@@ -40,7 +41,7 @@
     "eslint": "^3.0.1",
     "eslint-config-frost-standard": "^3.0.0",
     "loader.js": "^4.0.0",
-    "lodash": "4.15.0",
+    "lodash": "^4.15.0",
     "mocha": "3.0.2",
     "testdouble": "^1.6.0"
   },
@@ -57,7 +58,6 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",
     "ember-computed-decorators": ">=0.2.2 <2.0.0",
-    "lodash": "^4.15.0",
     "promise": "^7.1.1"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "cli-spinner": "^0.2.5",
     "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-blueprint-test-helpers": "^0.13.0",
@@ -54,7 +55,6 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "child-process-promise": "^2.1.3",
-    "cli-spinner": "^0.2.5",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -52,10 +52,12 @@
     "blueprint"
   ],
   "dependencies": {
+    "child-process-promise": "^2.1.3",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",
-    "ember-computed-decorators": ">=0.2.2 <2.0.0"
+    "ember-computed-decorators": ">=0.2.2 <2.0.0",
+    "promise": "^7.1.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",
     "ember-computed-decorators": ">=0.2.2 <2.0.0",
+    "lodash": "^4.15.0",
     "promise": "^7.1.1"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-truth-helpers": "^1.2.0",
     "eslint": "^3.0.1",
     "eslint-config-frost-standard": "^3.0.0",
+    "figures": "^1.7.0",
     "loader.js": "^4.0.0",
     "mocha": "3.0.2",
     "testdouble": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "cli-spinner": "^0.2.5",
     "ember-cli": "^2.7.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-blueprint-test-helpers": "^0.13.0",
@@ -41,7 +40,6 @@
     "eslint": "^3.0.1",
     "eslint-config-frost-standard": "^3.0.0",
     "loader.js": "^4.0.0",
-    "lodash": "^4.15.0",
     "mocha": "3.0.2",
     "testdouble": "^1.6.0"
   },
@@ -58,7 +56,9 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",
     "ember-computed-decorators": ">=0.2.2 <2.0.0",
-    "promise": "^7.1.1"
+    "promise": "^7.1.1",
+    "cli-spinner": "^0.2.5",
+    "lodash": "^4.15.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "blueprint"
   ],
   "dependencies": {
+    "chalk": "^1.1.3",
     "child-process-promise": "^2.1.3",
     "cli-spinner": "^0.2.5",
     "ember-cli-babel": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
-    "ember-lodash": "~0.0.6",
     "ember-resolver": "^2.0.3",
     "ember-truth-helpers": "^1.2.0",
     "eslint": "^3.0.1",
     "eslint-config-frost-standard": "^3.0.0",
     "loader.js": "^4.0.0",
+    "lodash": "4.15.0",
     "mocha": "3.0.2",
     "testdouble": "^1.6.0"
   },
@@ -53,9 +53,9 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-computed-decorators": ">=0.2.2 <2.0.0",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-sass": "^5.2.0"
+    "ember-cli-sass": "^5.2.0",
+    "ember-computed-decorators": ">=0.2.2 <2.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Change paradigm from install (first screen) + uninstall (second screen) to  features from the LTS (first screen) and other packages already installed (second screen)
- Support installing and uninstalling on the first screen
- Support uninstalling on the second screen
- Force reinstalling all the packages in the LTS even if they are already install (make sure to rerun the blueprints)
- Rework tests and add more tests
- Support installing addons and non addons
- Read LTS file for each lts addon in the current app and merge those
- Visual improvements
- Rework to make the code compliant with earlier versions of node and ES5
- Change the group state handling 

From:

| Packages state | Group state |
| --- | --- |
| new | new |
| update | update |
| installed | installed |
| new + update | new |
| new + installed | new |
| update + installed | update |

To:

| Packages state | Group state |
| --- | --- |
| new | new |
| update | update |
| installed | installed |
| new + update | update |
| new + installed | update |
| update + installed | update |
