### PR TITLE
Change the keyword that we are using to get the lts file.

### DIFF
--- a/lib/utils/recommended-groups.js
+++ b/lib/utils/recommended-groups.js
@@ -2,7 +2,7 @@
 
 var _ = require('lodash')
 
-var ADDON_LTS_KEYWORD = 'lts'
+var ADDON_LTS_KEYWORD = 'ember-cli-ecosystem-lts'
 var LTS_FILE_NAME = 'lts'
 var MANDATORY_KEY = 'mandatory'
 

--- a/package.json
+++ b/package.json
@@ -43,24 +43,24 @@
     "figures": "^1.7.0",
     "loader.js": "^4.0.0",
     "mocha": "3.0.2",
-    "testdouble": "^1.6.0"
+    "testdouble": "^1.6.0",
+    "lodash": "^4.15.0",
+    "promise": "^7.1.1",
+    "chalk": "^1.1.3",
+    "child-process-promise": "^2.1.3"
   },
   "keywords": [
     "ember-addon",
-    "frost",
     "long-term-support",
-    "lts",
+    "ember-cli-ecosystem",
+    "ember-cli-ecosystem-lts",
     "blueprint"
   ],
   "dependencies": {
-    "chalk": "^1.1.3",
-    "child-process-promise": "^2.1.3",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",
-    "ember-computed-decorators": ">=0.2.2 <2.0.0",
-    "lodash": "^4.15.0",
-    "promise": "^7.1.1"
+    "ember-computed-decorators": ">=0.2.2 <2.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "loader.js": "^4.0.0",
     "mocha": "3.0.2",
     "testdouble": "^1.6.0",
-    "lodash": "^4.15.0",
     "promise": "^7.1.1",
     "chalk": "^1.1.3",
     "child-process-promise": "^2.1.3"
@@ -60,7 +59,8 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",
-    "ember-computed-decorators": ">=0.2.2 <2.0.0"
+    "ember-computed-decorators": ">=0.2.2 <2.0.0",
+    "lodash": "^4.15.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Change the keyword we are using to get the addon that has lts.json files.
