### PR TITLE
Rename ember-frost-lts to ember-cli-ecosystem-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 
 [![Travis][ci-img]][ci-url] [![Coveralls][cov-img]][cov-url] [![NPM][npm-img]][npm-url]
 
+Work in progress !
+
+----
+TODO update the documentation
+
 # ember-frost-lts
 
  * [Installation](#Installation)

--- a/blueprints/ember-cli-ecosystem-installer/index.js
+++ b/blueprints/ember-cli-ecosystem-installer/index.js
@@ -18,13 +18,13 @@ var display = require('../../lib/ui/display')
 
 var MESSAGES = {
   QUESTION_RECOMMENDED_GROUPS:
-    'Choose the LTS features to install [' + figures.radioOn + ' ] or uninstall [' + figures.radioOff + ' ]',
+    'Choose the ecosystem features to install [' + figures.radioOn + ' ] or uninstall [' + figures.radioOff + ' ]',
   QUESTION_OTHER_GROUPS:
     'Choose the application specific packages to keep [' + figures.radioOn +
     ' ] or uninstall [' + figures.radioOff + ' ]',
-  INSTALLING_LTS: 'Installing LTS',
-  LOADING_VALIDATING_LTS_FILES: 'Loading and validating LTS files',
-  LOADED_VALIDATED_LTS_FILES: 'Loaded and validated LTS files\n',
+  INSTALLING_LTS: 'Installing ecosystem features',
+  LOADING_VALIDATING_LTS_FILES: 'Loading and validating ecosystem files',
+  LOADED_VALIDATED_LTS_FILES: 'Loaded and validated ecosystem files\n',
   CONFIRMATION: 'Would you like to confirm the following choices',
   SUMMARY: 'Summary of the operations that will be done',
   UNINSTALLING_PKGS: 'Uninstalling packages',
@@ -115,7 +115,7 @@ module.exports = {
     console.log('|    |   |    |  \\_____  \\ ')
     console.log('|    |___|    |  /        \\ ')
     console.log('|________\\____| /_________/ ')
-    console.log('Tool to install/uninstall LTS packages\n')
+    console.log('Tool to install/uninstall the LTS ecosystem packages\n')
   },
 
   /**

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-frost-lts",
+  "name": "ember-cli-ecosystem-installer",
   "dependencies": {
     "ember": "2.7.0",
     "ember-cli-shims": "0.1.3",

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 'use strict'
 
 module.exports = {
-  name: 'ember-frost-lts',
+  name: 'ember-cli-ecosystem-installer',
 
   included: function (app) {
     this._super.included(app)

--- a/lib/utils/external-application.js
+++ b/lib/utils/external-application.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var THIS_ADDON_NAME = 'ember-frost-lts'
+var THIS_ADDON_NAME = 'ember-cli-ecosystem-installer'
 
 module.exports = {
   /**

--- a/lib/utils/recommended-groups.js
+++ b/lib/utils/recommended-groups.js
@@ -3,33 +3,33 @@
 var _ = require('lodash')
 
 var ADDON_LTS_KEYWORD = 'ember-cli-ecosystem-lts'
-var LTS_FILE_NAME = 'lts'
+var ECOSYSTEM_FILE_NAME = 'lts'
 var MANDATORY_KEY = 'mandatory'
 
 module.exports = {
   /**
-   * Get the content of the LTS file (groups and packages).
+   * Get the content of the ecosystem LTS file (groups and packages).
    * @param {object} options all the options
-   * @returns {object} the content of the LTS file (groups and packages)
+   * @returns {object} the content of the ecosystem LTS file (groups and packages)
    */
-  _getLts: function (options) {
-    var ltsFilesContent = {}
+  _getEcosystemContent: function (options) {
+    var filesContent = {}
 
-    var ltsFilePath = options.ltsFile
-    if (ltsFilePath && ltsFilePath.trim() !== '') {
-      ltsFilesContent = require('../../' + ltsFilePath)
+    var filePath = options.ltsFile
+    if (filePath && filePath.trim() !== '') {
+      filesContent = require('../../' + filePath)
     } else {
       var addonPackages = options.project.addonPackages
 
       for (var addonName in addonPackages) {
         var addon = addonPackages[addonName]
         if (addon.pkg.keywords.indexOf(ADDON_LTS_KEYWORD) > -1) {
-          var ltsFile = require(addon.path + '/' + LTS_FILE_NAME + '.json')
-          _.merge(ltsFilesContent, ltsFile)
+          var file = require(addon.path + '/' + ECOSYSTEM_FILE_NAME + '.json')
+          _.merge(filesContent, file)
         }
       }
     }
-    return ltsFilesContent
+    return filesContent
   },
 
   /**
@@ -38,9 +38,9 @@ module.exports = {
    * @returns {object} an object containing all the mandatory groups and packages
    */
   getMandatoryGroupsNPkgs: function (options) {
-    var lts = this._getLts(options)
-    if (lts && lts[MANDATORY_KEY]) {
-      return lts[MANDATORY_KEY]
+    var ecosystemContent = this._getEcosystemContent(options)
+    if (ecosystemContent && ecosystemContent[MANDATORY_KEY]) {
+      return ecosystemContent[MANDATORY_KEY]
     }
     return {}
   },
@@ -51,13 +51,13 @@ module.exports = {
    * @returns {object} an object containing all the non mandatory groups and packages
    */
   getOptionalGroupsNPkgs: function (options) {
-    var lts = this._getLts(options)
+    var ecosystemContent = this._getEcosystemContent(options)
 
     var groupsNPkgs = {}
-    if (lts) {
-      for (var key in lts) {
+    if (ecosystemContent) {
+      for (var key in ecosystemContent) {
         if (key !== MANDATORY_KEY) {
-          groupsNPkgs[key] = lts[key]
+          groupsNPkgs[key] = ecosystemContent[key]
         }
       }
     }

--- a/node-tests/blueprints/ember-cli-ecosystem-installer.js
+++ b/node-tests/blueprints/ember-cli-ecosystem-installer.js
@@ -42,8 +42,7 @@ var otherPkgsToSelectByDefaylt = [
   'ember-load-initializers',
   'ember-resolver',
   'ember-welcome-page',
-  'loader.js',
-  'ember-frost-lts'
+  'loader.js'
 ]
 
 var installedPkgsMochaCoreD3 = [
@@ -55,7 +54,7 @@ var installedPkgsChai = [
   {name: 'ember-cli-mocha', version: '0.2.0', dev: true}        // installed
 ]
 
-describe('Acceptance: ember generate ember-frost-lts', function () {
+describe('Acceptance: ember generate ember-cli-ecosystem-installer', function () {
   setupTestHooks(this)
 
   var prompt, packagesToInstall, packagesToUninstall
@@ -88,7 +87,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
   })
 
   it('No package to install (empty file)', function () {
-    var args = ['ember-frost-lts', '--lts-file=node-tests/mock/empty-lts.json']
+    var args = ['ember-cli-ecosystem-installer', '--lts-file=node-tests/mock/empty-lts.json']
     td.when(prompt(td.matchers.anything())).thenResolve({
       userInputOtherGroups: otherPkgsToSelectByDefaylt,
       confirmSelection: 'y'
@@ -103,7 +102,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
   })
 
   it('Single package', function () {
-    var args = ['ember-frost-lts', '--lts-file=node-tests/mock/single-package-lts.json']
+    var args = ['ember-cli-ecosystem-installer', '--lts-file=node-tests/mock/single-package-lts.json']
     td.when(prompt(td.matchers.anything())).thenResolve({
       userInputRecommendGroups: ['ember-prop-types'],
       userInputOtherGroups: otherPkgsToSelectByDefaylt,
@@ -120,7 +119,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
   })
 
   it('Single group', function () {
-    var args = ['ember-frost-lts', '--lts-file=node-tests/mock/single-group-lts.json']
+    var args = ['ember-cli-ecosystem-installer', '--lts-file=node-tests/mock/single-group-lts.json']
     td.when(prompt(td.matchers.anything())).thenResolve({
       userInputRecommendGroups: ['package3'],
       userInputOtherGroups: otherPkgsToSelectByDefaylt,
@@ -139,7 +138,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
   describe('Package and group', function () {
     var args
     beforeEach(function () {
-      args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts.json']
+      args = ['ember-cli-ecosystem-installer', '--lts-file=node-tests/mock/package-group-lts.json']
     })
 
     describe('User request', function () {
@@ -551,7 +550,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
   describe('Mandatory', function () {
     var args
     beforeEach(function () {
-      args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts-mandatory.json']
+      args = ['ember-cli-ecosystem-installer', '--lts-file=node-tests/mock/package-group-lts-mandatory.json']
     })
 
     it('Already installed package', function () {
@@ -618,7 +617,7 @@ describe('Acceptance: ember generate ember-frost-lts', function () {
   describe('Mandatory + Optional', function () {
     var args
     beforeEach(function () {
-      args = ['ember-frost-lts', '--lts-file=node-tests/mock/package-group-lts-mandatory-optional.json']
+      args = ['ember-cli-ecosystem-installer', '--lts-file=node-tests/mock/package-group-lts-mandatory-optional.json']
     })
 
     it('Already installed package', function () {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-frost-lts",
+  "name": "ember-cli-ecosystem-installer",
   "version": "0.1.6",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
@@ -13,7 +13,7 @@
     "utest": "mocha node-tests --recursive",
     "lint": "eslint *.js addon app blueprints config tests"
   },
-  "repository": "git@github.com:ciena-frost/ember-frost-lts.git",
+  "repository": "git@github.com:ciena-frost/ember-ecli-ecosystem-installer.git",
   "engines": {
     "node": ">= 5.0.0"
   },

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>frost-lts testbed</title>
+    <title>ember-cli-ecosystem-installer testbed</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -1,2 +1,2 @@
-frost-lts testbed
-{{frost-lts}}
+ember-cli-ecoystem-installer testbed
+{{ember-cli-ecoystem-installer}}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Rename ember-frost-lts to ember-cli-ecosystem-installer
