### PR TITLE
Install addons with npm-install to avoid exact version issue

### DIFF
--- a/blueprints/ember-cli-ecosystem-installer/index.js
+++ b/blueprints/ember-cli-ecosystem-installer/index.js
@@ -187,11 +187,11 @@ module.exports = {
 
           var addAddonsPromise
           if (!_.isEmpty(addons)) {
-            addAddonsPromise = self.addAddonsToProject({ packages: addons, saveDev: true })
+            addAddonsPromise = self.addAddonsToProject({ packages: addons })
           }
           var addPkgsPromise
           if (!_.isEmpty(nonAddons)) {
-            addPkgsPromise = self.addPackagesToProject(nonAddons)
+            addPkgsPromise = self.addPackagesToProject(nonAddons.concat(addons))
           }
 
           return Promise.all([addAddonsPromise, addPkgsPromise])


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [X] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Install the dependencies with `addPackagesToProject` and `addAddonsToProject` to avoid problem with the exact version set for `addAddonsToProject`
