### PR TITLE
Force install addon first and then install pkg second.

### DIFF
--- a/blueprints/ember-cli-ecosystem-installer/index.js
+++ b/blueprints/ember-cli-ecosystem-installer/index.js
@@ -193,7 +193,10 @@ module.exports = {
             addAddonsPromise = self.addAddonsToProject({ packages: addons })
           }
 
-          return Promise.all([addAddonsPromise, addPkgsPromise])
+          return Promise.resolve(addAddonsPromise)
+            .then(function () {
+              return Promise.resolve(addPkgsPromise)
+            })
         })
       }
     }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Make sure that addon install is done before package install
