### PR TITLE
test forcing save-dev and save-exact

### DIFF
--- a/lib/ember-cli-libs/tasks/npm-task.js
+++ b/lib/ember-cli-libs/tasks/npm-task.js
@@ -29,8 +29,10 @@ module.exports = Task.extend({
       // by default, do install peoples optional deps
       'optional': 'optional' in options ? options.optional : true,
       'save': !!options.save,
-      'save-dev': !!options['save-dev'],
-      'save-exact': !!options['save-exact']
+      'save-dev': true,
+      // !!options['save-dev'],
+      'save-exact': false
+      // !!options['save-exact']
     }
 
     var packages = options.packages || []


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- try forcing save-dev: true and save-exact: false
