### PR TITLE
Fix issue with non (^|~)x.x.x target

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,4 @@ bower_components/**
 connect.lock/**
 coverage/**
 libpeerconnection.log
+coverage/*/**

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -108,7 +108,7 @@ module.exports = {
   isInstalled: function (currentTarget, requestedTarget) {
     var dct = this.getDecomposedTarget(currentTarget)
     var drt = this.getDecomposedTarget(requestedTarget)
-    if (requestedTarget && currentTarget) {
+    if (dct && drt) {
       return dct.major > drt.major ||
              dct.major === drt.major && dct.minor > drt.minor ||
              dct.major === drt.major && dct.minor === drt.minor && dct.patch >= drt.patch
@@ -124,10 +124,12 @@ module.exports = {
   getDecomposedTarget: function (target) {
     var regularExpresion = PKG_TARGET_REGEX
     var match = regularExpresion.exec(target)
-    return {
-      major: match[1],
-      minor: match[2],
-      patch: match[3]
+    if (match && match.length > 4) {
+      return {
+        major: match[1],
+        minor: match[2],
+        patch: match[3]
+      }
     }
   },
 

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -124,7 +124,7 @@ module.exports = {
   getDecomposedTarget: function (target) {
     var regularExpresion = PKG_TARGET_REGEX
     var match = regularExpresion.exec(target)
-    if (match && match.length > 4) {
+    if (match && match.length >= 4) {
       return {
         major: match[1],
         minor: match[2],
@@ -184,9 +184,11 @@ module.exports = {
       if (requestedTarget && currentTarget) {
         var dct = this.getDecomposedTarget(currentTarget)
         var drt = this.getDecomposedTarget(requestedTarget)
-        return dct.major > drt.major ||
-          dct.major === drt.major && dct.minor > drt.minor ||
-          dct.major === drt.major && dct.minor === drt.minor && dct.patch > drt.patch
+        if (dct && drt) {
+          return dct.major > drt.major ||
+            dct.major === drt.major && dct.minor > drt.minor ||
+            dct.major === drt.major && dct.minor === drt.minor && dct.patch > drt.patch
+        }
       }
     }
     return false


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Fix issue with non (^|~)x.x.x target during the gathering of the current state 
