### PR TITLE
Missing ecosystem installer in package json of target app

### DIFF
--- a/blueprints/ember-cli-ecosystem-installer/index.js
+++ b/blueprints/ember-cli-ecosystem-installer/index.js
@@ -225,6 +225,7 @@ module.exports = {
   updatePkgJsonFile: function (packages) {
     var path = this.path + '/package.json'
     var pkgJson = require(path)
+    console.log(pkgJson)
     if (pkgJson && pkgJson.devDependencies) {
       packages.forEach((pkg) => {
         pkgJson.devDependencies[pkg.name] = pkg.target

--- a/lts.json
+++ b/lts.json
@@ -1,2 +1,3 @@
 {
+  "ember-prop-types": "^2.0.0"
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- Try to figure out why, installer package not in `package.json`
